### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e4c36b3f7ec1400bd92ef42567b687f20f3c3c4",
-        "sha256": "0jq8715g4f8ccmk18df0m0mmq2fdnivaxhx4x61cmkyjps31f868",
+        "rev": "f2f8e282204266187f471b3353728843a577bc7e",
+        "sha256": "1gflpsgagg487xj5p9911b7pvqh2vmw7vfg4hi6pnbrqkilm5kj6",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6e4c36b3f7ec1400bd92ef42567b687f20f3c3c4.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/f2f8e282204266187f471b3353728843a577bc7e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                             |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`517d2b96`](https://github.com/NixOS/nixpkgs/commit/517d2b963f35abbca8ccc364141bc5f2b4e92974) | `llvm_12: fix cross-compilation`                                                           |
| [`30f537a5`](https://github.com/NixOS/nixpkgs/commit/30f537a5fb108f08b54efe0397256ed1068dafc0) | `zk-shell: switch to python3, cleanup`                                                     |
| [`2ff702e9`](https://github.com/NixOS/nixpkgs/commit/2ff702e9375982c8236301c44a44c4788290baf3) | `cargo-crev: 0.19.4 -> 0.20.1`                                                             |
| [`b295f5a6`](https://github.com/NixOS/nixpkgs/commit/b295f5a6d9e4239aa53affd004e6b3573e40efed) | `vscodium: 1.59.1 -> 1.60.0`                                                               |
| [`dfd8733a`](https://github.com/NixOS/nixpkgs/commit/dfd8733a76aee0d5994191e11b2822f11c4a6a8d) | `rebar3: 3.16.1 -> 3.17.0`                                                                 |
| [`865be33d`](https://github.com/NixOS/nixpkgs/commit/865be33dfa3ef7673ed3ce366dddf32960ac23f1) | `haskellPackages: mark builds failing on hydra as broken`                                  |
| [`a7753f4f`](https://github.com/NixOS/nixpkgs/commit/a7753f4f953993020db4abd61eff1e719bd1c564) | `python3.pkgs.osmpythontools: 0.3.0 -> 0.3.2`                                              |
| [`8dbf2741`](https://github.com/NixOS/nixpkgs/commit/8dbf274116cb6dcdb875fee0df58b301f95c72ef) | `haskell.packages.ghc901, haskell.packages.ghc921: use hlint_3_3_4 instead of hlint_3_3_1` |
| [`9675a865`](https://github.com/NixOS/nixpkgs/commit/9675a865c9c3eeec36c06361f7215e109925654c) | `buildGo117{Module,Package}: disable, go_1_17: disable on x86_64-darwin`                   |
| [`273ff5cf`](https://github.com/NixOS/nixpkgs/commit/273ff5cf17cfce7dbf02a9f9ffb9a8b117b59c2f) | `go_1_17: init at 1.17.1`                                                                  |
| [`c7bae28f`](https://github.com/NixOS/nixpkgs/commit/c7bae28f8195beb646e29f712d5d88cb8988a931) | `haskellPackages.urlencoded: unmark as broken`                                             |
| [`65135081`](https://github.com/NixOS/nixpkgs/commit/65135081f63ca2f5eaa9b7b54bfc7bf31502cfd6) | `cocoapods: 1.10.2 -> 1.11.0`                                                              |
| [`f6def75c`](https://github.com/NixOS/nixpkgs/commit/f6def75c962e6f5138444c44c7bc88a1ce392c14) | `cocoapods: make update script set gemfile platform to ruby`                               |
| [`190a9065`](https://github.com/NixOS/nixpkgs/commit/190a90650403e8381c09be7ac11da74bc5797d54) | `python3Packages.aiohttp-swagger: 1.0.5 -> 1.0.15`                                         |
| [`98018cce`](https://github.com/NixOS/nixpkgs/commit/98018cce2c85bf73b651e608ab797c9d96b9d737) | `linuxPackages.bbswitch: use kernel's make flags`                                          |
| [`7def23db`](https://github.com/NixOS/nixpkgs/commit/7def23dbbbab6c5a60d7736a64d1df3ff4ebe449) | `python39Packages.eventlet: activate tests, add SuperSandro2000 as maintainer`             |
| [`62acbfd1`](https://github.com/NixOS/nixpkgs/commit/62acbfd1b7314dc555fab032482da55416f7a4bf) | `nix-query-tree-viewer: 0.2.0 -> 0.2.1`                                                    |
| [`d2b6db71`](https://github.com/NixOS/nixpkgs/commit/d2b6db713335e861b2804dfc5c21364914488a31) | `python3Packages.amcrest: 1.8.0 -> 1.8.1`                                                  |
| [`a078cb9a`](https://github.com/NixOS/nixpkgs/commit/a078cb9aabbdc3cd5dd61bb97dcf9eb8ce4c10ef) | `python3Packages.aiomusiccast: 0.9.1 -> 0.9.2`                                             |
| [`eb33c5cb`](https://github.com/NixOS/nixpkgs/commit/eb33c5cb42f8226167fab94888ff670ab2a00972) | `gitleaks: 7.6.0 -> 7.6.1`                                                                 |
| [`bd5f4702`](https://github.com/NixOS/nixpkgs/commit/bd5f47022c3994840d2daf7867cac66c9ba2963f) | `ghc8.8.4: fix mingw build`                                                                |
| [`eea8e3ea`](https://github.com/NixOS/nixpkgs/commit/eea8e3eacec12fe4e46d3ecb8e3cbbd03a10b2f0) | `ghc8.10.7: fix mingw build`                                                               |
| [`f80b0fd0`](https://github.com/NixOS/nixpkgs/commit/f80b0fd0a8131baa06bb47d8809e2d15b990e7d2) | `gvm-libs: init at 21.4.1`                                                                 |
| [`0aedbf2b`](https://github.com/NixOS/nixpkgs/commit/0aedbf2bd993c9f3c76a7b35d728db7ab9fcaad1) | `gallery-dl: add marsam to maintainers`                                                    |
| [`b77012c1`](https://github.com/NixOS/nixpkgs/commit/b77012c1d033569202af16d24bd9e30aafabcc2b) | `gallery-dl: 1.18.3 -> 1.18.4`                                                             |
| [`61b713ab`](https://github.com/NixOS/nixpkgs/commit/61b713abd6280acc87cbe7724bfe000acf3627cb) | `haskell.packages.*.ghc-api-compat: fix across all supported sets`                         |
| [`bcc8e62a`](https://github.com/NixOS/nixpkgs/commit/bcc8e62a2392b61f49840267c4d17cf383d85a8a) | `haskellPackages.git-annex: update sha256 for 8.20210903`                                  |
| [`538e32b7`](https://github.com/NixOS/nixpkgs/commit/538e32b74022709e62f814a774ff20c56157aa70) | `haskellPackages: regenerate package set based on current config`                          |
| [`121cc7c0`](https://github.com/NixOS/nixpkgs/commit/121cc7c0dc4ebe4df5b63b62c9e744f4adef19bf) | `all-cabal-hashes: 2021-09-03T13:28:39Z -> 2021-09-06T23:06:06Z`                           |
| [`c725d873`](https://github.com/NixOS/nixpkgs/commit/c725d8735e61bc81e9741036bb4f4f9f8cb8767b) | `haskellPackages: stackage-lts 18.8 -> 18.9`                                               |
| [`d3631d44`](https://github.com/NixOS/nixpkgs/commit/d3631d44ed0f7761bd236bbd24094e116fc482ec) | `megapixels: Fix schema compilation`                                                       |
| [`4ab6df39`](https://github.com/NixOS/nixpkgs/commit/4ab6df39c44d1c47d6ef452351a419aa421dc33e) | `sqls: init at 0.2.19`                                                                     |
| [`1a7238dd`](https://github.com/NixOS/nixpkgs/commit/1a7238dd323483d3929865bea8c6223ae7cad484) | `fragments: init at 1.5`                                                                   |
| [`37134b60`](https://github.com/NixOS/nixpkgs/commit/37134b6072dd01e55f12a8c3a501f7969398a808) | `transmission: fix missing optional dependencies`                                          |
| [`adc89ca6`](https://github.com/NixOS/nixpkgs/commit/adc89ca60d3dada24549f00d65fe2fea1ce33c84) | `libutp: init at unstable-2017-01-02`                                                      |
| [`54099a06`](https://github.com/NixOS/nixpkgs/commit/54099a0676c1bc5c598dc475230d7c931a48abd4) | `dht: init at 0.25`                                                                        |