### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f2f8e282204266187f471b3353728843a577bc7e",
-        "sha256": "1gflpsgagg487xj5p9911b7pvqh2vmw7vfg4hi6pnbrqkilm5kj6",
+        "rev": "0171610faad12bdc6757b483b7e7219780123ff1",
+        "sha256": "19vf00ai28d9y0jb5sw4j67hwdym9zh44mn60nsj46a9b73rm4di",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f2f8e282204266187f471b3353728843a577bc7e.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/0171610faad12bdc6757b483b7e7219780123ff1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
| [`62cc1f90`](https://github.com/NixOS/nixpkgs/commit/62cc1f90e554a370ddb08b5c8c7bcec619665602) | `cni-plugin-flannel: init at 20210910 (#137412)`                                                                               |
| [`a5a4149b`](https://github.com/NixOS/nixpkgs/commit/a5a4149b2f6bf56b0513c57c99948ee058c4a025) | `gnome.quadrapassel: 40.1 -> 40.2`                                                                                             |
| [`7d761f42`](https://github.com/NixOS/nixpkgs/commit/7d761f4228e0550bc8e106ba5b9ac155d08ec489) | `gnome.nautilus: 40.1 -> 40.2`                                                                                                 |
| [`1cc9e66b`](https://github.com/NixOS/nixpkgs/commit/1cc9e66b24fe52cc804893f998e3e52833fda4fd) | `gnome.gnome-weather: 40.0 -> 40.1`                                                                                            |
| [`ae42c3a0`](https://github.com/NixOS/nixpkgs/commit/ae42c3a0630c63bfc44f7f3c6e6ebc6d7c5f4554) | `gnome.gnome-shell-extensions: 40.3 -> 40.4`                                                                                   |
| [`d0712a84`](https://github.com/NixOS/nixpkgs/commit/d0712a8462451a5fc615202bf7824bd134460340) | `gjs: 1.68.2 -> 1.68.3`                                                                                                        |
| [`cfae9b1b`](https://github.com/NixOS/nixpkgs/commit/cfae9b1b99439288368693dbde795ba462680ec9) | `gexiv2: 0.12.2 -> 0.12.3`                                                                                                     |
| [`124e8afb`](https://github.com/NixOS/nixpkgs/commit/124e8afb6a3f4a623dea0f206cc5c2b5e4577ba8) | `gnome.gnome-desktop: 40.3 -> 40.4`                                                                                            |
| [`c6e09932`](https://github.com/NixOS/nixpkgs/commit/c6e09932da02f6a92530644447f010f708793fbb) | `android-studio-canary: 2021.1.1.5 → 2021.1.1.11`                                                                              |
| [`ebc030ce`](https://github.com/NixOS/nixpkgs/commit/ebc030ce758ba1dd7576d68a235fbdad15844d65) | `joshuto: init at 0.9.0`                                                                                                       |
| [`c4c93989`](https://github.com/NixOS/nixpkgs/commit/c4c93989e834f4de1fc14b1e612e0c4f0fd847a0) | `gnome.eog: 40.2 -> 40.3`                                                                                                      |
| [`0ea1b56e`](https://github.com/NixOS/nixpkgs/commit/0ea1b56e6cd1ccfc1b69bc225969a21318e34b2b) | `python3Packages.dpath: 2.0.3 -> 2.0.4`                                                                                        |
| [`cb78051c`](https://github.com/NixOS/nixpkgs/commit/cb78051ccda2282df41f5a71c4c07078c9eaad75) | `gnome.devhelp: 40.0 -> 40.1`                                                                                                  |
| [`7fad7281`](https://github.com/NixOS/nixpkgs/commit/7fad7281d86fb063b57aaf11d78dabd506c80332) | `wike: init at 1.5.6`                                                                                                          |
| [`7d7ab4f8`](https://github.com/NixOS/nixpkgs/commit/7d7ab4f8958faf86577be7dc93aa534ae2848d9c) | `gitRepo: 2.16 -> 2.16.7`                                                                                                      |
| [`3935d8a9`](https://github.com/NixOS/nixpkgs/commit/3935d8a9d2497424d72d4c774c4851d5c5e19fdc) | `airshipper: init at 0.6.0`                                                                                                    |
| [`50d04198`](https://github.com/NixOS/nixpkgs/commit/50d04198ca5e14783c2b4253f6dfdd38e5e4abff) | `gofu: init at unstable-2021-09-11`                                                                                            |
| [`729b2d37`](https://github.com/NixOS/nixpkgs/commit/729b2d373ee414d46bafc5dc98381df4f0b26f04) | `gensio: 2.2.8 -> 2.2.9`                                                                                                       |
| [`e8528a7e`](https://github.com/NixOS/nixpkgs/commit/e8528a7e591508f711a92ec120c1f9ac2bba1195) | `maintainers/teams: fix capitalisation`                                                                                        |
| [`0eb567a2`](https://github.com/NixOS/nixpkgs/commit/0eb567a2da26e89eb8dd1673c5665633623b1a74) | `python39Packages.subunit2sql: init at 1.10.0`                                                                                 |
| [`02a5e643`](https://github.com/NixOS/nixpkgs/commit/02a5e643207ab8d78d5cf7ab21e961368030794a) | `python39Packages.stestr: init at 3.2.0`                                                                                       |
| [`7b4c9f88`](https://github.com/NixOS/nixpkgs/commit/7b4c9f880fc5deddee0f37eeb60a235c01261efc) | `python39Packages.python-openstackclient: init at 5.6.0`                                                                       |
| [`1c8b1984`](https://github.com/NixOS/nixpkgs/commit/1c8b1984e8604a5cb53855a41ff5ebbefab716c7) | `python39Packages.python-cinderclient: init at 8.1.0`                                                                          |
| [`260ae860`](https://github.com/NixOS/nixpkgs/commit/260ae860121b6eab3df4c452792f3c15817dc5ab) | `python39Packages.subunit: add alias from python-subunit`                                                                      |
| [`5836d578`](https://github.com/NixOS/nixpkgs/commit/5836d578ded885255162f2f8e798741d4260f6ec) | `python39Packages.oslotest: init at 4.5.0`                                                                                     |
| [`ac15248e`](https://github.com/NixOS/nixpkgs/commit/ac15248e5b68b1a9bcd487331939d55afa3ac902) | `python39Packages.oslo-utils: init at 4.10.0`                                                                                  |
| [`ec305549`](https://github.com/NixOS/nixpkgs/commit/ec305549b4ef9ea17835e7e4c4184812a565c54f) | `python39Packages.oslo-serialization: init at 4.2.0`                                                                           |
| [`76dd2dba`](https://github.com/NixOS/nixpkgs/commit/76dd2dbadf2aec2dbaa3542b50d9127e562c87f6) | `python39Packages.oslo-log: 4.6.0`                                                                                             |
| [`b5c77041`](https://github.com/NixOS/nixpkgs/commit/b5c7704111aa9a6364f0c5395051ff568b208918) | `python39Packages.oslo-i18n: init at 5.1.0`                                                                                    |
| [`1adeb1f2`](https://github.com/NixOS/nixpkgs/commit/1adeb1f2527f6fa6b01d1985bab8c0a4734c4217) | `python39Packages.oslo-db: init at 11.0.0`                                                                                     |
| [`7f338392`](https://github.com/NixOS/nixpkgs/commit/7f338392e1a535851ec842ad89571fdec4c3913c) | `python39Packages.oslo-context: init at 3.3.1`                                                                                 |
| [`243294b2`](https://github.com/NixOS/nixpkgs/commit/243294b2b46d1d865eb490f61d601bedc05a5dfd) | `python39Packages.oslo-config: init at 8.7.1`                                                                                  |
| [`13bf19d4`](https://github.com/NixOS/nixpkgs/commit/13bf19d49b40dd76793475b80853c65c0f8f0d84) | `python39Packages.oslo-concurrency: init at 4.4.1`                                                                             |
| [`98a7fd7d`](https://github.com/NixOS/nixpkgs/commit/98a7fd7d452521f33a1c3ac48ab4c5b03c5d63cc) | `python39Packages.os-service-type: init at 1.7.0`                                                                              |
| [`2e7f79bb`](https://github.com/NixOS/nixpkgs/commit/2e7f79bb2cd0e23859621dff467c451cb925521f) | `python39Packages.keystoneauth1: init at 4.3.1`                                                                                |
| [`bb915c38`](https://github.com/NixOS/nixpkgs/commit/bb915c3840b0042c86cbcd0a5d02fb72a19882e5) | `python39Packages.debtcollector: init at 2.3.0`                                                                                |
| [`7bee25da`](https://github.com/NixOS/nixpkgs/commit/7bee25daa244e1ddb9c1918f6afe7f2536bb5b0e) | `python39Packages.eventlet: propagate pyopenssl as it is not only used in tests, cleanup pythonOlder inputs, update meta data` |
| [`8530881c`](https://github.com/NixOS/nixpkgs/commit/8530881c1d25628570cfdb61009dead19067c386) | `gnomeExtensions.unite: 54 -> 55`                                                                                              |
| [`e92c1c42`](https://github.com/NixOS/nixpkgs/commit/e92c1c42d9d0579a817d5c02748c60ece830abd2) | `gdl: 3.34.0 -> 3.40.0`                                                                                                        |
| [`36649cb7`](https://github.com/NixOS/nixpkgs/commit/36649cb7da0a9117cd6c2d4c0dfd1651801e822f) | `sqlfluff: 0.6.4 -> 0.6.5`                                                                                                     |
| [`366c6708`](https://github.com/NixOS/nixpkgs/commit/366c670892bd38066102c47bbcc7fd39c7e709bb) | `evolution: 3.40.3 -> 3.40.4`                                                                                                  |
| [`97cfb35e`](https://github.com/NixOS/nixpkgs/commit/97cfb35eb89661d99cda7a3727656595b3350c8d) | `pythonPackages.debugpy: 1.4.2 → 1.4.3`                                                                                        |
| [`689e408a`](https://github.com/NixOS/nixpkgs/commit/689e408afc4266fdb7521ff50f46770c35c6df37) | `pythonPackages.debugpy: 1.4.1 → 1.4.2`                                                                                        |
| [`042119ca`](https://github.com/NixOS/nixpkgs/commit/042119cadebeea9034aa517b46d8ef4fd359a087) | `qt514.qt3d: fix upstream URL`                                                                                                 |
| [`a0c0f339`](https://github.com/NixOS/nixpkgs/commit/a0c0f33910315b28cd09769811776352f75cbcd5) | `erlang-ls: 0.18.0 -> 0.19.0`                                                                                                  |
| [`3303ff68`](https://github.com/NixOS/nixpkgs/commit/3303ff68f2e6ead41e50e7fb11556396b3d11277) | `loksh: init at 6.9`                                                                                                           |
| [`f07b4aff`](https://github.com/NixOS/nixpkgs/commit/f07b4aff1569b1f12d0eb71e76d0c2b4b8173379) | `enum4linux-ng: 1.0.1 -> 1.1.0`                                                                                                |
| [`a85cefb6`](https://github.com/NixOS/nixpkgs/commit/a85cefb6f55e3aa7a30d5525606d336933104f7d) | `dnscontrol: 3.11.0 -> 3.12.0`                                                                                                 |
| [`325d5e78`](https://github.com/NixOS/nixpkgs/commit/325d5e783d7f462f3d83f1df8df22941c43111b3) | `dictdDBs.wiktionary: 20210201 -> 20210901`                                                                                    |
| [`bc4d8649`](https://github.com/NixOS/nixpkgs/commit/bc4d8649d9de90c710b290faf984417c0390b660) | `dcp9020cdw{lpr,-cupswrapper}: init at 1.1.2`                                                                                  |
| [`dbd8269e`](https://github.com/NixOS/nixpkgs/commit/dbd8269eabc92f69c80fa09549ee3b4fd74ba8a4) | `maintainers: add pshirshov`                                                                                                   |
| [`ef2939ac`](https://github.com/NixOS/nixpkgs/commit/ef2939ac375b6d4037d73f7822ebfeb758d61783) | `python3Packages.python-novaclient: init at 17.5.0`                                                                            |
| [`7d790eca`](https://github.com/NixOS/nixpkgs/commit/7d790ecae6d1659fea643c222b05f356ececab6f) | `vimPlugins.vim-clap: Fix maple override hash`                                                                                 |
| [`8b1a5873`](https://github.com/NixOS/nixpkgs/commit/8b1a5873c8dabb78b49874bf80a0c1ba49c37ea4) | `python38Packages.sphinxcontrib-bibtex: 2.4.0 -> 2.4.1`                                                                        |
| [`6b5c571f`](https://github.com/NixOS/nixpkgs/commit/6b5c571f31c762ba15a0501a27df8a14033a36af) | `devpi-client: 5.2.1 -> 5.2.2`                                                                                                 |
| [`2902a792`](https://github.com/NixOS/nixpkgs/commit/2902a7921b67dbb908375dfafe4cff35130a2a9c) | `ccache: 4.4 → 4.4.1`                                                                                                          |
| [`ecadda1f`](https://github.com/NixOS/nixpkgs/commit/ecadda1f25082b8fba3f6603c0c19c2115c87c62) | `cargo-msrv: 0.8.0 -> 0.9.0`                                                                                                   |
| [`e2302344`](https://github.com/NixOS/nixpkgs/commit/e23023445b624fcb376640ee2d9c2904b0805fec) | `boundary: 0.5.1 -> 0.6.0`                                                                                                     |
| [`9e1267fa`](https://github.com/NixOS/nixpkgs/commit/9e1267fad1eab96866d0688d68229a1c7f1bade6) | `python38Packages.flask-restx: 0.4.0 -> 0.5.1`                                                                                 |
| [`98bfb51d`](https://github.com/NixOS/nixpkgs/commit/98bfb51d00a2e5b94cf9aa5d56e7eaa82001387e) | `erlang: make systemd optional, add `pkgs.beam_minimal``                                                                       |
| [`28b5133c`](https://github.com/NixOS/nixpkgs/commit/28b5133cce47d31f4cf4b0ae2c40a11e87850449) | `geogebra: 5-0-644-0 -> 5-0-662-0`                                                                                             |
| [`8b1972ed`](https://github.com/NixOS/nixpkgs/commit/8b1972ed70a2adb5fbf9de09d1a3c51dd5dad8f9) | `sniffglue: 0.12.1 -> 0.13.0`                                                                                                  |
| [`eb2457fe`](https://github.com/NixOS/nixpkgs/commit/eb2457fe2674f7e28b97b33de3f464e01c19c7b5) | `maddy: include systemd units`                                                                                                 |
| [`524b8196`](https://github.com/NixOS/nixpkgs/commit/524b819690d43badf8e7b8000fb5893c58167111) | `torrential: 1.1.0 -> 2.0.0`                                                                                                   |
| [`01a6eec3`](https://github.com/NixOS/nixpkgs/commit/01a6eec3a23e6c6ff8b18c1dee03de0ef408ac75) | `python3Packages.python-keystoneclient: init at 4.2.0`                                                                         |
| [`b125cedc`](https://github.com/NixOS/nixpkgs/commit/b125cedcc180820a19ea10d897993382b4e2f01a) | `python3Packages.openstacksdk: init at 0.59.0`                                                                                 |
| [`cddb6e32`](https://github.com/NixOS/nixpkgs/commit/cddb6e320fa110dcfb6bf6cb348d0fbb506145d8) | `python3Packages.osc-lib: init at 2.4.1`                                                                                       |
| [`9af54f47`](https://github.com/NixOS/nixpkgs/commit/9af54f4731b936dc254e27096ea21eb80f78f230) | `python3Packages.hacking: init at 4.1.0`                                                                                       |
| [`8a390019`](https://github.com/NixOS/nixpkgs/commit/8a3900198f555881834c04921b4e64736b5f9755) | `calibre: remove unused input`                                                                                                 |
| [`1d7917e6`](https://github.com/NixOS/nixpkgs/commit/1d7917e64e072b1aeeae13de1c249333b7083387) | `trustedGrub, trustedGrub-for-HP: apply upstream fix for fresh glibc`                                                          |
| [`b0555f01`](https://github.com/NixOS/nixpkgs/commit/b0555f0187607a34fa9a2516b75159efb6acc298) | `pythonPackages.wavedrom: init at 2.0.3.post2`                                                                                 |
| [`e7386532`](https://github.com/NixOS/nixpkgs/commit/e7386532a4f95d2003fc85df50311598d67e720b) | `scrcpy: add msfjarvis to maintainers`                                                                                         |
| [`6e701416`](https://github.com/NixOS/nixpkgs/commit/6e7014169fa62c9f25a24d57cf46dbc23d6199d5) | `scrcpy: 1.18 -> 1.19`                                                                                                         |
| [`72c2ad9c`](https://github.com/NixOS/nixpkgs/commit/72c2ad9c5a0c08ae113b3cd10d0c579c3ee2c11d) | `cargo-audit: 0.15.0 -> 0.15.1`                                                                                                |
| [`f21712ed`](https://github.com/NixOS/nixpkgs/commit/f21712edaa61d8c0b0f577751de08f3a4f10ee46) | `importCargoLock: add docs how to run these tests`                                                                             |
| [`b13ce4ae`](https://github.com/NixOS/nixpkgs/commit/b13ce4ae6b4dc3fcfaa3c56f310c42eeefe6aec0) | `masterpdfeditor: 5.7.20 -> 5.7.90`                                                                                            |
| [`b3fd09e9`](https://github.com/NixOS/nixpkgs/commit/b3fd09e93b2bc69ff7b7f46d13e106f06e6f3311) | `build2: init at 0.13.0`                                                                                                       |
| [`3a31564d`](https://github.com/NixOS/nixpkgs/commit/3a31564d2f3bbcb1cff972103075aa4445dba6fa) | `mkvtoolnix: 60.0.0 -> 61.0.0`                                                                                                 |
| [`2f9ec583`](https://github.com/NixOS/nixpkgs/commit/2f9ec5838eb8f1fcfbb5808a482b08b403bfbbdd) | `nixos/doc: fix merged items in 20.09 rel notes`                                                                               |
| [`21312f6d`](https://github.com/NixOS/nixpkgs/commit/21312f6d92d18aef9321cbdb8534e83d935b18d6) | `sn0int: 0.21.2 -> 0.22.0`                                                                                                     |
| [`79a08e9f`](https://github.com/NixOS/nixpkgs/commit/79a08e9f592e04f6327d7d99f4b32cba30554939) | `exploitdb: 2021-09-08 -> 2021-09-10`                                                                                          |
| [`873a099e`](https://github.com/NixOS/nixpkgs/commit/873a099e240d01c2527b963fd4d06f8192e72442) | `python3Packages.boschshcpy: 0.2.20 -> 0.2.23`                                                                                 |
| [`399afe5d`](https://github.com/NixOS/nixpkgs/commit/399afe5dbc55d1065411a08ba1c32d6c0f558650) | `python3Packages.identify: 2.2.13 -> 2.2.14`                                                                                   |
| [`a18e2ca9`](https://github.com/NixOS/nixpkgs/commit/a18e2ca99f325657f6264719a3a3a2b069006abc) | `python3Packages.responses: 0.13.4 -> 0.14.0`                                                                                  |
| [`34cc1821`](https://github.com/NixOS/nixpkgs/commit/34cc1821dbac6ab7152e830a1571ab5481040aa6) | `importCargoLock: add tests for branch and tag`                                                                                |
| [`0ef3a1a1`](https://github.com/NixOS/nixpkgs/commit/0ef3a1a1e44a56eb73865c2a97489cdc357a2f64) | `python3Packages.python-lsp-server: 1.2.1 -> 1.2.2`                                                                            |
| [`49d14930`](https://github.com/NixOS/nixpkgs/commit/49d149307296fa49a2cf8d265d51e11100efc9a0) | `python3Packages.poolsense: 0.0.8 -> 0.1.0`                                                                                    |
| [`28e7cd98`](https://github.com/NixOS/nixpkgs/commit/28e7cd989082bbfae88ac3c6fd473a8bfcc87bb4) | `python3Packages.mutf8: 1.0.3 -> 1.0.4`                                                                                        |
| [`b435e06d`](https://github.com/NixOS/nixpkgs/commit/b435e06df0e199ac54ddd15c91946fd621603215) | `skytemple: 1.2.5 -> 1.3.0`                                                                                                    |
| [`97456cb4`](https://github.com/NixOS/nixpkgs/commit/97456cb46ad0cffec86e1b59c75984929df5dc68) | `python3Packages.skytemple-ssb-debugger: 1.2.5 -> 1.3.0`                                                                       |
| [`09d99a9f`](https://github.com/NixOS/nixpkgs/commit/09d99a9f49519b4a61a921006a4b7b1d875dd610) | `python3Packages.skytemple-files: 1.2.4 -> 1.3.0`                                                                              |
| [`f0949550`](https://github.com/NixOS/nixpkgs/commit/f09495500ec8a1d0ad0a70399baa8b0532871992) | `tflint: 0.31.0 -> 0.32.0`                                                                                                     |
| [`35f805cf`](https://github.com/NixOS/nixpkgs/commit/35f805cf9fcc5788aab8f59cfd963d62ffee8203) | `nodejs-16_x: 16.9.0 -> 16.9.1`                                                                                                |
| [`1b9987bf`](https://github.com/NixOS/nixpkgs/commit/1b9987bfd9678179115c9cacd444e7bad8df3a36) | `python38Packages.databricks-connect: 8.1.11 -> 8.1.12`                                                                        |
| [`04c4a6d2`](https://github.com/NixOS/nixpkgs/commit/04c4a6d25ef3033725058b39d0285cec017995a9) | `python38Packages.azure-mgmt-containerservice: 16.1.0 -> 16.2.0`                                                               |
| [`5699a14a`](https://github.com/NixOS/nixpkgs/commit/5699a14a3bc64d1122393f31ff7b14f4f385bdbe) | `libxklavier: Update git repository URL`                                                                                       |
| [`370dc36c`](https://github.com/NixOS/nixpkgs/commit/370dc36c330be13be9eb478d09e27de460b81bcd) | `audacity: Fix URL to audacity_xdg_paths.patch`                                                                                |
| [`0f54dbf5`](https://github.com/NixOS/nixpkgs/commit/0f54dbf54f5230b9927862f86f032710b8315f85) | `calibre: Add python3Packages.jeepney as dependency`                                                                           |
| [`12d41756`](https://github.com/NixOS/nixpkgs/commit/12d41756b076cc5dffc83ef36e4966b63606e47e) | `noto-fonts: Fix path to zopflipng, remove broken check`                                                                       |
| [`fe29ded3`](https://github.com/NixOS/nixpkgs/commit/fe29ded365463d985f00d2dbbf4dd63c22bc597f) | `kodi: Fix git revisions for libdvd{css,nva,read}`                                                                             |
| [`2f96b697`](https://github.com/NixOS/nixpkgs/commit/2f96b6977be05e6a6df0a7f6f14c0942164c2834) | `kdeltachat: unstable-2021-08-22 -> unstable-2021-09-10`                                                                       |
| [`33bbe582`](https://github.com/NixOS/nixpkgs/commit/33bbe582996d4941ef059e82be628abfcc32e7c6) | `mautrix-facebook: Support journald logging.`                                                                                  |
| [`2f1631a6`](https://github.com/NixOS/nixpkgs/commit/2f1631a6039792ee215084b89a9a0d7f55c62009) | `mautrix-facebook: init at 0.3.1`                                                                                              |
| [`3f795e07`](https://github.com/NixOS/nixpkgs/commit/3f795e071dd0e368f09c308248743653c9bb5903) | `python3Packages.flask-appbuilder: 3.3.1 -> 3.3.2`                                                                             |
| [`9c82ab55`](https://github.com/NixOS/nixpkgs/commit/9c82ab55b1ae40c162aaf7d91c9314f66ad4e075) | `nixos/xserver: fix extraLayouts with displayManager.sx.enable`                                                                |
| [`00b1ac5b`](https://github.com/NixOS/nixpkgs/commit/00b1ac5b234a59fdc6a8f5c7689d895d046d0952) | `importCargoLock: git deps with rev, branch or tag`                                                                            |
| [`6094ee5b`](https://github.com/NixOS/nixpkgs/commit/6094ee5b4f9cf5873bc4f67b400b06084d6800dd) | `chromiumDev: 95.0.4628.3 -> 95.0.4636.4`                                                                                      |
| [`7b7342d6`](https://github.com/NixOS/nixpkgs/commit/7b7342d6484f3d88b150b96a8b4e191e2ae01ee4) | `maintainers: add cameronnemo`                                                                                                 |
| [`5aaf779d`](https://github.com/NixOS/nixpkgs/commit/5aaf779d48401ad8060f982a803e408594191349) | `unp: 2.0-pre7 -> 2.0-pre9`                                                                                                    |
| [`1fcb91f1`](https://github.com/NixOS/nixpkgs/commit/1fcb91f1a32d93d3f4bf87a03be6a63588530f02) | `maintainers: add airwoodix`                                                                                                   |
| [`462070bd`](https://github.com/NixOS/nixpkgs/commit/462070bddfb3fba1607d744c5fdab6a84094ba65) | `nix-direnv-flakes: alias flake-enabled nix-direnv`                                                                            |
| [`f0d39060`](https://github.com/NixOS/nixpkgs/commit/f0d390606338befd2b88a3f34b03946c54e2e27a) | `libhandy: only run tests on non-darwin`                                                                                       |
| [`18e19d4b`](https://github.com/NixOS/nixpkgs/commit/18e19d4b5a7892bfd4e67a00d0a1c023eb921c65) | `python3Packages.dungeon-eos: init at 0.0.4`                                                                                   |
| [`1840f6ce`](https://github.com/NixOS/nixpkgs/commit/1840f6ce57d9279a055dadd846448d49a7c10de4) | `python3Packages.rapidfuzz: 1.5.0 -> 1.6.0`                                                                                    |
| [`35759160`](https://github.com/NixOS/nixpkgs/commit/35759160d6a8581a53e671c378dbc8e60b0a6385) | `acpica-tools: fix cross`                                                                                                      |
| [`895592ae`](https://github.com/NixOS/nixpkgs/commit/895592ae3b518489440d3e441f035f3f90dfbd00) | `python38Packages.progressbar2: 3.53.1 -> 3.53.2`                                                                              |
| [`712f00a9`](https://github.com/NixOS/nixpkgs/commit/712f00a9a1d96346f315c4a2d0d0daa5e423f5fa) | `menyoki: init at 1.5.3`                                                                                                       |
| [`2f3c684c`](https://github.com/NixOS/nixpkgs/commit/2f3c684cfb1abf2467b12b082ed05b247798d48c) | `btcpayserver: 1.2.0 -> 1.2.3`                                                                                                 |
| [`a46ac13f`](https://github.com/NixOS/nixpkgs/commit/a46ac13f5b14825e89c6f21290aeb8ffb2d55c1a) | `python3Packages.ueagle: init at 0.0.2`                                                                                        |