### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0171610faad12bdc6757b483b7e7219780123ff1",
-        "sha256": "19vf00ai28d9y0jb5sw4j67hwdym9zh44mn60nsj46a9b73rm4di",
+        "rev": "db88608d8c811a93b74c99cfa1224952afc78200",
+        "sha256": "078nmdgsqb5khza9bifs29h6lw6n2m38y699g27yrwyp7jhsv74m",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/0171610faad12bdc6757b483b7e7219780123ff1.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/db88608d8c811a93b74c99cfa1224952afc78200.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`2444c114`](https://github.com/NixOS/nixpkgs/commit/2444c11431a37e04de025b63f6a12bdd05d2f4c1) | `nixos/kernel: add 5.14 to kernel test-suite`                                  |
| [`c1fe8aea`](https://github.com/NixOS/nixpkgs/commit/c1fe8aea8f501d88f459d9cdeb5d3f42757776c8) | `signal-cli: 0.8.5 -> 0.9.0`                                                   |
| [`06971f97`](https://github.com/NixOS/nixpkgs/commit/06971f9777d3355b8942459babe59a7be6a64a3b) | `libnbd: 1.9.3 -> 1.9.5`                                                       |
| [`21ca66be`](https://github.com/NixOS/nixpkgs/commit/21ca66bef063c4da0bf74ec3c148ebf1508aaaf3) | `gvm-libs: 21.4.1 -> 21.4.2`                                                   |
| [`d5540fa1`](https://github.com/NixOS/nixpkgs/commit/d5540fa18f9bc7e914e9b48d462c5cddfc7fb013) | `telfhash: unstable-2021-01-29 -> 0.9.8 (#137305)`                             |
| [`271b6edb`](https://github.com/NixOS/nixpkgs/commit/271b6edba253bba11f331de5c00ec72d84877c62) | `corrscope: Fix ffmpeg package to ffmpeg-full`                                 |
| [`4b0699e5`](https://github.com/NixOS/nixpkgs/commit/4b0699e5d034890388c3a42ee871c788b3427a53) | `linux_xanmod: 5.13.13 -> 5.14.3`                                              |
| [`55130d56`](https://github.com/NixOS/nixpkgs/commit/55130d56aa950cda73f61f51686703507e21ffe5) | `watson: use packageOverrides`                                                 |
| [`354b1864`](https://github.com/NixOS/nixpkgs/commit/354b1864025c8f70c976ade3f3af99f792d7bd08) | `vimUtils.vimGenDocHook: dont copy the folder (again)`                         |
| [`1c490409`](https://github.com/NixOS/nixpkgs/commit/1c4904092b2d824256ebba20cc9b7ba9c941e18a) | `neovim.tests: test vim-plug too`                                              |
| [`ff8e690f`](https://github.com/NixOS/nixpkgs/commit/ff8e690f97e80382b2d13676e45e9ca395c3c75d) | `python39Packages.setuptools-rust: adopt`                                      |
| [`ba1b9152`](https://github.com/NixOS/nixpkgs/commit/ba1b9152c367785618c05f5a8aa04be540e89d35) | `python38Packages.numcodecs: 0.9.0 -> 0.9.1`                                   |
| [`6f2ce2a6`](https://github.com/NixOS/nixpkgs/commit/6f2ce2a65e33ca00c5cb7f32b7ee871b05d66735) | `treewide: remove danieldk as maintainer from a set of packages`               |
| [`d94bd5c5`](https://github.com/NixOS/nixpkgs/commit/d94bd5c599fb225591786a45fb89b081a1189d85) | `svtplay-dl: 4.2 -> 4.3`                                                       |
| [`a88557ec`](https://github.com/NixOS/nixpkgs/commit/a88557ec5f52ee5270978899e4a7e887f49861fc) | `gitstatus: 1.5.2 -> 1.5.3`                                                    |
| [`119c9e1f`](https://github.com/NixOS/nixpkgs/commit/119c9e1f700c05cb98451db2359e08cf87cdd5e5) | `nixos/rabbitmq: clean-up after f091420c1d194ad398142959266f18493da1ff83`      |
| [`9ef79a5f`](https://github.com/NixOS/nixpkgs/commit/9ef79a5f128518f3cf0c46439816daa0c4634587) | `gmailctl: 0.8.0 -> 0.9.0`                                                     |
| [`e3cf7c1a`](https://github.com/NixOS/nixpkgs/commit/e3cf7c1a909ca3e572401ea615203eccbbfa6fdb) | `gnuk: switch to python3`                                                      |
| [`06a94f6d`](https://github.com/NixOS/nixpkgs/commit/06a94f6d6317bc6ff2e712e643b1050e26a1c89d) | `python38Packages.pex: 2.1.48 -> 2.1.49`                                       |
| [`a51701e3`](https://github.com/NixOS/nixpkgs/commit/a51701e3f318377ad743d97e0a9b53d9b8ba45b0) | `android-backup-extractor: init at 20210909062443-4c55371 (#137516)`           |
| [`7f22c185`](https://github.com/NixOS/nixpkgs/commit/7f22c1851fd1baa3b9149f3b6202f6350324e943) | `gnuplot: Allow compiling with libcaca (#137523)`                              |
| [`b0403854`](https://github.com/NixOS/nixpkgs/commit/b04038541242bdbe0891fc42a7b215cd02519f48) | `flynt: init at 0.66 (#137177)`                                                |
| [`2b022a97`](https://github.com/NixOS/nixpkgs/commit/2b022a979ab40832bf35442fe5a5e5466e97619e) | `zsh-fzf-tab: Support darwin platform (#137514)`                               |
| [`1cee7f6c`](https://github.com/NixOS/nixpkgs/commit/1cee7f6cf43612e1ee72d41201366c48275b5b8c) | `v2ray: 4.41.1 -> 4.42.1`                                                      |
| [`f460ae5a`](https://github.com/NixOS/nixpkgs/commit/f460ae5aaa2f08efaff6f43a5e88b4b546427b8e) | `notejot: 3.1.2 -> 3.1.5`                                                      |
| [`6ab20337`](https://github.com/NixOS/nixpkgs/commit/6ab2033765f409f0c65511c86bbc6e20d9bbca4e) | `quakespasm: 0.93.2 -> 0.94.1`                                                 |
| [`688b9b65`](https://github.com/NixOS/nixpkgs/commit/688b9b65cb95a7d0bd65d09acfbe249f95a8a024) | `hubble: init at 0.8.2`                                                        |
| [`d279bf97`](https://github.com/NixOS/nixpkgs/commit/d279bf976744ba6a48144909a7214ddaef6c9cd0) | `taskopen: modernize`                                                          |
| [`1d8bdf53`](https://github.com/NixOS/nixpkgs/commit/1d8bdf5389d49ba7216dd20bb7245ebb5208329d) | `stuntman: init at 1.2.16`                                                     |
| [`1dc56f1d`](https://github.com/NixOS/nixpkgs/commit/1dc56f1dc81ac409acab530266f8101c3e078dca) | `quakespasm: add SDL2 support; add Darwin support`                             |
| [`e4a49641`](https://github.com/NixOS/nixpkgs/commit/e4a49641ae4e0a06062c973891ed54fddf3b9e04) | `openems: fix eval`                                                            |
| [`5698fc0d`](https://github.com/NixOS/nixpkgs/commit/5698fc0dfc669166371b07a12ed6908696b2776c) | `linux-rt_5_4: 5.4.143-rt63 -> 5.4.143-rt64`                                   |
| [`be590b86`](https://github.com/NixOS/nixpkgs/commit/be590b86e26f9144e7c2719650c57772bb797ed9) | `linux: 5.4.144 -> 5.4.145`                                                    |
| [`b81ac243`](https://github.com/NixOS/nixpkgs/commit/b81ac24356c60e63c7daccedf278c500f1ca5179) | `linux: 5.14.2 -> 5.14.3`                                                      |
| [`f0878c65`](https://github.com/NixOS/nixpkgs/commit/f0878c65eb8824957a2eabb863cefac5b09df3b3) | `linux: 5.13.15 -> 5.13.16`                                                    |
| [`71348196`](https://github.com/NixOS/nixpkgs/commit/71348196a0aa2ca74487c7f8e24a02aad5ae42ab) | `linux: 5.10.63 -> 5.10.64`                                                    |
| [`c5513615`](https://github.com/NixOS/nixpkgs/commit/c5513615310ed4a24e7d7ec1722ea6893eae4d9f) | `blocksat-cli: 0.3.2 -> 0.4.0`                                                 |
| [`acdec49e`](https://github.com/NixOS/nixpkgs/commit/acdec49e965b9556bcb89e0ce3fec844a2cff469) | `eduke32: 20210722 -> 20210910`                                                |
| [`8112bb92`](https://github.com/NixOS/nixpkgs/commit/8112bb92f9df718eaa077ec77109eecc60240a72) | `eduke32: implement proper macOS support`                                      |
| [`fd9a52c4`](https://github.com/NixOS/nixpkgs/commit/fd9a52c466e03a19f8d88a607ea122d7376a28d8) | `unpackerr: 0.9.7 -> 0.9.8`                                                    |
| [`15fdbbe4`](https://github.com/NixOS/nixpkgs/commit/15fdbbe4e9742fe81fdabc6867f34480983e2cb9) | `python38Packages.relatorio: 0.9.3 -> 0.10.0`                                  |
| [`036c82cc`](https://github.com/NixOS/nixpkgs/commit/036c82cca19779ba4ff7abf085226d606e085a12) | `libvirt: fix tarball hash`                                                    |
| [`75eaccdc`](https://github.com/NixOS/nixpkgs/commit/75eaccdcbc79f908902638bbea4aef33ebdad712) | `wiki-js: 2.5.201 -> 2.5.214`                                                  |
| [`e2e065ab`](https://github.com/NixOS/nixpkgs/commit/e2e065ab538889f5de2c190786a418f54cffefff) | `nuclei: 2.5.0 -> 2.5.1`                                                       |
| [`fba1e377`](https://github.com/NixOS/nixpkgs/commit/fba1e37757b55c2ebdb5ff9066377af51e6c1d1c) | `python3Packages.mutf8: 1.0.4 -> 1.0.5`                                        |
| [`6fb71e46`](https://github.com/NixOS/nixpkgs/commit/6fb71e46ca0b38e3d8a1bcc37f795fef8c4b8873) | `sysdig: fix linking against libabseil`                                        |
| [`f6211582`](https://github.com/NixOS/nixpkgs/commit/f6211582a16c535700178921200247bc59b4e81e) | `linux-router: init at 0.6.2`                                                  |
| [`151fd8a6`](https://github.com/NixOS/nixpkgs/commit/151fd8a64cf66473b0007f204d7a2fc4a9e804a2) | `maintainers: add x3ro`                                                        |
| [`a7b1e14a`](https://github.com/NixOS/nixpkgs/commit/a7b1e14af9f7d57a9773549d6902d7e119340014) | `wine{Unstable,Staging}: 6.16 -> 6.17`                                         |
| [`6d1ece38`](https://github.com/NixOS/nixpkgs/commit/6d1ece3818fb70aa64856d9d24bb39b5546fed67) | `octant: 0.23.0 -> 0.24.0`                                                     |
| [`252edd9d`](https://github.com/NixOS/nixpkgs/commit/252edd9d164240b6e40f978e830216d20857856f) | `obsidian: 0.12.12 -> 0.12.15`                                                 |
| [`365a8fb5`](https://github.com/NixOS/nixpkgs/commit/365a8fb5f9316271b5499702fbe49eadc81f0b8c) | `nncp: 7.6.0 -> 7.7.0`                                                         |
| [`6bc05449`](https://github.com/NixOS/nixpkgs/commit/6bc0544998096343b8b4917c22295894bfb35d80) | `nextcloud-news-updater: 10.0.1 -> 11.0.0`                                     |
| [`72d984d2`](https://github.com/NixOS/nixpkgs/commit/72d984d20e28666214349fa197712dc951d4314c) | `moonraker: unstable-2021-07-18 -> unstable-2021-09-04`                        |
| [`65fb0203`](https://github.com/NixOS/nixpkgs/commit/65fb0203850fe824763f545e72dfef420a08295c) | `mm-common: 1.0.2 -> 1.0.3`                                                    |
| [`f095deec`](https://github.com/NixOS/nixpkgs/commit/f095deec649195d6f37378da4d8461dd0955bdf9) | `matrix-synapse-plugins.matrix-synapse-mjolnir-antispam: 0.1.17 -> 0.1.19`     |
| [`03d20cbc`](https://github.com/NixOS/nixpkgs/commit/03d20cbced6d28aa299c280d42147af434b19ad7) | `matrix-synapse-plugins.matrix-synapse-ldap3: 0.1.4 -> 0.1.5`                  |
| [`0fc38b1e`](https://github.com/NixOS/nixpkgs/commit/0fc38b1eb2aa6e3c5d2d60135e280e4d3f6d87ca) | `libsigcxx30: 3.0.6 -> 3.0.7`                                                  |
| [`be5e48ac`](https://github.com/NixOS/nixpkgs/commit/be5e48ac7e40ba2223d77301941b88315717df03) | `libnma: 1.8.30 -> 1.8.32`                                                     |
| [`80ab542a`](https://github.com/NixOS/nixpkgs/commit/80ab542af868455cda81718e134d726dc8348e76) | `steam: fix steamwebhelper`                                                    |
| [`d0eca54c`](https://github.com/NixOS/nixpkgs/commit/d0eca54c81370cdb9bd7e8c68fb9ba2f002f5b21) | `kodiPackages.youtube: 6.8.14+matrix.1 -> 6.8.17+matrix.1`                     |
| [`11fa1732`](https://github.com/NixOS/nixpkgs/commit/11fa1732bb87a4fab407db02737a3d640eb508cf) | `kodiPackages.inputstreamhelper: 0.5.5+matrix.1 -> 0.5.8+matrix.1`             |
| [`117a1b97`](https://github.com/NixOS/nixpkgs/commit/117a1b97458ba5c43b4c0187ef2fdfa1e8b21ed2) | `klipper: unstable-2021-07-15 -> unstable-2021-09-03`                          |
| [`022c300d`](https://github.com/NixOS/nixpkgs/commit/022c300df10d5e90ea9738441fd3d978b80596e5) | `quill: 0.2.4 -> 0.2.5`                                                        |
| [`07109dd4`](https://github.com/NixOS/nixpkgs/commit/07109dd495bd3e8b6ef39d737d93b7e721b06ff3) | `nixos/kubernetes: add cni-plugin-flannel to kubelet.cni.packages`             |
| [`a8bd9dcd`](https://github.com/NixOS/nixpkgs/commit/a8bd9dcd7c0d2fbbfdedf89a4359959793f15e25) | `cni-plugin-flannel: move to flannel directory`                                |
| [`72dd18cc`](https://github.com/NixOS/nixpkgs/commit/72dd18cc55f5097d3a0ae808125dc74155891e72) | `python38Packages.scp: 0.13.6 -> 0.14.0`                                       |
| [`7fb52b13`](https://github.com/NixOS/nixpkgs/commit/7fb52b1325a383b7bd83aa2552f6d9d57106d241) | `nixos: nixos/doc/manual/installation/installing.xml to CommonMark`            |
| [`623aa314`](https://github.com/NixOS/nixpkgs/commit/623aa314dd27f186bf3edc2e02445c359ade9604) | `bochs: Enable VT-x/VMX emulation`                                             |
| [`b9797768`](https://github.com/NixOS/nixpkgs/commit/b97977681eec4233bcc0428ccdd93a038f810ebf) | `lua: add LUA_PATH changes to release notes`                                   |
| [`496b8abf`](https://github.com/NixOS/nixpkgs/commit/496b8abf789b891f5355ea2265416e5121855308) | `Apply suggestions from code review`                                           |
| [`88842910`](https://github.com/NixOS/nixpkgs/commit/88842910b52c146bc5ef9c78eed34e5e570ef76c) | `lua: introduced a lua lib`                                                    |
| [`0b6d33c2`](https://github.com/NixOS/nixpkgs/commit/0b6d33c2ed177be6d937e3043ac77252007a77b1) | `prosody: simplify lua aspects`                                                |
| [`2ce4d216`](https://github.com/NixOS/nixpkgs/commit/2ce4d21663113020195f1d953e360213954645b3) | `go_1_16: 1.16.7 -> 1.16.8`                                                    |
| [`f6cc04fd`](https://github.com/NixOS/nixpkgs/commit/f6cc04fd6576b2c9d1f4cc4d31a2fd0e66a7f99f) | `astromenace: add meta.mainProgram`                                            |
| [`03806dfe`](https://github.com/NixOS/nixpkgs/commit/03806dfee73c18ce4d55542af46e7af8816a673b) | `awesome: use a luaEnv`                                                        |
| [`823d0d83`](https://github.com/NixOS/nixpkgs/commit/823d0d835ce789726d8df681c6ba286f04d8998c) | `vis: simplify thanks to lua update`                                           |
| [`e9c921a3`](https://github.com/NixOS/nixpkgs/commit/e9c921a301f76e4708d6361e5278651244791e35) | `mudlet: remove unneeded LUA_CPATH`                                            |
| [`607e3893`](https://github.com/NixOS/nixpkgs/commit/607e389393328623c7c6bb745569550db7346a78) | `megapixels: 1.2.0 -> 1.3.0`                                                   |
| [`56f823dd`](https://github.com/NixOS/nixpkgs/commit/56f823dd5c596ef6374f99a22ca63168ff6f6fb9) | `vimPlugins: shorten rtpPath`                                                  |
| [`6285fa7f`](https://github.com/NixOS/nixpkgs/commit/6285fa7f9ddf1e76f1b8ca78a55486d2c1f91448) | `vtk_9: 9.0.1 -> 9.0.3`                                                        |
| [`d126476d`](https://github.com/NixOS/nixpkgs/commit/d126476d4060d997bfb440d2fa3756eca3feeefa) | `grpc: add patch to revert alias to abseil mutex`                              |
| [`781766e3`](https://github.com/NixOS/nixpkgs/commit/781766e30cb5726d5558773be3ec70305becb91d) | `treewide: yank wicd as it is abandoned`                                       |
| [`f74154a4`](https://github.com/NixOS/nixpkgs/commit/f74154a4b99e6f0d3e9b381d8f008aa9fe61963d) | `sc-controller: switch to python3 fork`                                        |
| [`7a9f5d69`](https://github.com/NixOS/nixpkgs/commit/7a9f5d69c88efbf907bbffacaa21fbf159d23284) | `ncdns: 2020-11-22 -> 2021-07-18`                                              |
| [`3dde4fd3`](https://github.com/NixOS/nixpkgs/commit/3dde4fd38bc51ccf8fc486bb58678007b4e6ee1a) | `textplots: init at 0.8.0`                                                     |
| [`8ac8c33d`](https://github.com/NixOS/nixpkgs/commit/8ac8c33df1723d2384136416248017f5a65e294b) | `mitmproxy: 6.0.2 -> 7.0.2`                                                    |
| [`f50e55af`](https://github.com/NixOS/nixpkgs/commit/f50e55afdc542f919bd1facfbcbaf30c1ca12e75) | `Update pkgs/top-level/aliases.nix`                                            |
| [`a45c76d7`](https://github.com/NixOS/nixpkgs/commit/a45c76d73ddb01e6d7aa9c5f6c9d67a4ef4e0ed0) | `bandwidth: 1.9.4 -> 1.10.1, enable on arm`                                    |
| [`bd763298`](https://github.com/NixOS/nixpkgs/commit/bd763298edeb1a7db10e39b1eac205b38a91f9de) | `typora: remove`                                                               |
| [`231dd103`](https://github.com/NixOS/nixpkgs/commit/231dd103c7a0d3d62dc535b4b3b5aac78a3655fb) | `python3Packages.beautifulsoup4: 4.9.3 -> 4.10.0`                              |
| [`c57b83df`](https://github.com/NixOS/nixpkgs/commit/c57b83df008cdc03ff97b4ba7f77990ba250bb05) | `thunderbird-bin: Add update instructions comment`                             |
| [`7d0988f2`](https://github.com/NixOS/nixpkgs/commit/7d0988f213425b12da3845cd006aa12f26479750) | `thunderbird-78: 78.13.0 -> 78.14.0`                                           |
| [`023d0ce7`](https://github.com/NixOS/nixpkgs/commit/023d0ce720cd42dbac5d78fbe18e663b05267e5b) | `python3Packages.growattserver: 1.0.2 -> 1.1.0`                                |
| [`12a73316`](https://github.com/NixOS/nixpkgs/commit/12a73316bb6349f1004d9331fcd26aba0171450c) | `fstar: 2021.08.27 -> 2021.09.11`                                              |
| [`44853e8c`](https://github.com/NixOS/nixpkgs/commit/44853e8cf338e9b42c1d3069287b9655658325bb) | `nixos/git: init`                                                              |
| [`f2321130`](https://github.com/NixOS/nixpkgs/commit/f2321130100790c6bdf2ff618d81130e085e2896) | `tdesktop: 2.9.3 -> 3.0.1`                                                     |
| [`7c147222`](https://github.com/NixOS/nixpkgs/commit/7c147222011f45cd19249f34fa55d620d225f9a7) | `oha: init at 0.4.6`                                                           |
| [`4a4394ed`](https://github.com/NixOS/nixpkgs/commit/4a4394ed460fead79fe3d1bb07b36a07e67dacb9) | `python38Packages.dropbox: 11.18.0 -> 11.19.0`                                 |
| [`69e75754`](https://github.com/NixOS/nixpkgs/commit/69e75754d57b4c9785058d663daa3817745930aa) | `nixos/privacyidea: use `sudo(8)` that's configured via the module`            |
| [`21ddf57f`](https://github.com/NixOS/nixpkgs/commit/21ddf57f7200c00ca521880ea3f35622a683b091) | `canta-theme: 2021-07-06 -> 2021-09-08`                                        |
| [`b8efe91c`](https://github.com/NixOS/nixpkgs/commit/b8efe91ce225c4413301089d52f47c07f384e38e) | `nixos: nixos/doc/manual/development/writing-modules.xml to CommonMark`        |
| [`785d40d4`](https://github.com/NixOS/nixpkgs/commit/785d40d4d872a13642eb7eba7a5bc57f6ba5cdc5) | `nixos: nixos/doc/manual/configuration/profiles.xml to CommonMark`             |
| [`2e808c81`](https://github.com/NixOS/nixpkgs/commit/2e808c8144bc864d8b837cc59ffbf52dc360a1d4) | `nixos: nixos/doc/manual/configuration/networking.xml to CommonMark`           |
| [`4c10e0ff`](https://github.com/NixOS/nixpkgs/commit/4c10e0ff9ddea45b344134228dd5874b9ae0bd06) | `nixos: nixos/doc/manual/configuration/file-systems.xml to CommonMark`         |
| [`7d7d2a44`](https://github.com/NixOS/nixpkgs/commit/7d7d2a44556a43d8b65bde4ea95267cf6525c9f4) | `nixos: nixos/doc/manual/configuration/package-mgmt.xml to CommonMark`         |
| [`12a9632a`](https://github.com/NixOS/nixpkgs/commit/12a9632ab09b131d82032896d2adc6bc9904ea77) | `nixos: nixos/doc/manual/devlopment/nixos-tests.xml to CommonMark`             |
| [`45c1d8f4`](https://github.com/NixOS/nixpkgs/commit/45c1d8f4aa37029cb3704db2421e55a308f583c0) | `nixos: nixos/doc/manual/configuration/config-syntax.xml to CommonMark`        |
| [`8ce611b9`](https://github.com/NixOS/nixpkgs/commit/8ce611b9fb664b6860b55f003d0b42a1dd0ab8e9) | `nixos: nixos/doc/manual/configuration/declarative-packages.xml to CommonMark` |
| [`3d711cfc`](https://github.com/NixOS/nixpkgs/commit/3d711cfc5e1205672dd6808909773dba8c26fe34) | `nixos: nixos/doc/manual/administration/troubleshooting.xml to CommonMark`     |
| [`5aaeddee`](https://github.com/NixOS/nixpkgs/commit/5aaeddee5f2da59e5664d5c215ff08cfb6a6f252) | `nixos: nixos/doc/manual/administration/containers.xml to CommonMark`          |
| [`ec4c589e`](https://github.com/NixOS/nixpkgs/commit/ec4c589e8da964edbdbba5f9942c549227d10665) | `golangci-lint: 1.42.0 -> 1.42.1`                                              |
| [`4361d044`](https://github.com/NixOS/nixpkgs/commit/4361d0448e87e08d1533ef98b387d360ef2ed268) | `python38Packages.azure-mgmt-servicefabric: 1.0.0 -> 2.0.0`                    |
| [`f9ce4291`](https://github.com/NixOS/nixpkgs/commit/f9ce429132ac68635327f79fe16ca28dc70bf2f3) | `python38Packages.azure-mgmt-relay: 1.0.0 -> 1.1.0`                            |
| [`8129bba3`](https://github.com/NixOS/nixpkgs/commit/8129bba33cd62c4fb5667dc844944eddc33aad96) | `python38Packages.azure-mgmt-resource: 19.0.0 -> 20.0.0`                       |
| [`d83697e4`](https://github.com/NixOS/nixpkgs/commit/d83697e448777cd846cecb639f39c865137e679d) | `python38Packages.asyncssh: 2.7.0 -> 2.7.1`                                    |
| [`266fe481`](https://github.com/NixOS/nixpkgs/commit/266fe4814befff219e84d9d6f8280ba069dfc9ca) | `python38Packages.Markups: 3.1.1 -> 3.1.2`                                     |
| [`a82ea7ea`](https://github.com/NixOS/nixpkgs/commit/a82ea7eaac10d22bee5edd250e06ad5c887e0127) | `kubeconform: 0.4.8 -> 0.4.10`                                                 |
| [`4843df81`](https://github.com/NixOS/nixpkgs/commit/4843df81766903c6af7b9641f41c42790fd270ba) | `jellyfin: 10.7.6 -> 10.7.7`                                                   |
| [`db84ea4c`](https://github.com/NixOS/nixpkgs/commit/db84ea4cfbefe33a410e369701501cb62a57d7ff) | `docker-buildx: 0.6.2 -> 0.6.3`                                                |
| [`daeb4e9e`](https://github.com/NixOS/nixpkgs/commit/daeb4e9e1411c9cc8f6de2784ab07db408902351) | `discordchatexporter-cli: 2.30 -> 2.30.1`                                      |
| [`31a2a945`](https://github.com/NixOS/nixpkgs/commit/31a2a9455eb0ed6ac046ef53c4c08f5db50e7e63) | `python38Packages.flexmock: 0.10.8 -> 0.10.9`                                  |
| [`8ef36c0a`](https://github.com/NixOS/nixpkgs/commit/8ef36c0aa5da19846f212e4e845e5984ac73096b) | `cloudflared: 2021.8.6 -> 2021.8.7`                                            |
| [`d1e83ab1`](https://github.com/NixOS/nixpkgs/commit/d1e83ab10a26965393a1bca7569f81cb47ac1bb4) | `civetweb: 1.14 -> 1.15`                                                       |
| [`2194cab7`](https://github.com/NixOS/nixpkgs/commit/2194cab7049081c807027bcdb61f98ce5b7e9995) | `bazarr: 0.9.7 -> 0.9.8`                                                       |
| [`bb154257`](https://github.com/NixOS/nixpkgs/commit/bb1542577323d84c5004ff992191f24c3a278919) | `azure-storage-azcopy: 10.11.0 -> 10.12.1`                                     |
| [`637186d3`](https://github.com/NixOS/nixpkgs/commit/637186d3cd38f307b4419a44b12ff5d0414bcd67) | `python38Packages.wordfreq: 2.5 -> 2.5.1`                                      |
| [`e9e16e29`](https://github.com/NixOS/nixpkgs/commit/e9e16e29950c94abb47a0ad781e78bb12029e213) | `python38Packages.azure-mgmt-rdbms: 9.0.0 -> 9.1.0`                            |
| [`beba9f42`](https://github.com/NixOS/nixpkgs/commit/beba9f4200b63f1ebca305efb92dd2407caaf40e) | `python38Packages.django-mailman3: 1.3.5 -> 1.3.6`                             |
| [`d1de5af6`](https://github.com/NixOS/nixpkgs/commit/d1de5af6754e80bd32709686c45cffbc5ebb20ca) | `abseil-cpp: 20210324.1 -> 20210324.2`                                         |
| [`fc968260`](https://github.com/NixOS/nixpkgs/commit/fc968260c5c06513f89815d3e9bc6526b02b1c22) | `python38Packages.azure-mgmt-netapp: 4.0.0 -> 5.0.0`                           |
| [`22fb92b7`](https://github.com/NixOS/nixpkgs/commit/22fb92b744c72989d3628654301bb1b7c86773ea) | `python38Packages.azure-mgmt-keyvault: 9.0.0 -> 9.1.0`                         |
| [`0afd6fe4`](https://github.com/NixOS/nixpkgs/commit/0afd6fe4cb591f92a967b54c13104a6967eb4e89) | `chore: Ignore JetBrains IDEA configuration`                                   |
| [`7221585f`](https://github.com/NixOS/nixpkgs/commit/7221585f89c72078b070d14e4f00f439db0b92fb) | `nixos/deliantra-server: add settings module for Deliantra MMORPG server`      |
| [`c5d61a5e`](https://github.com/NixOS/nixpkgs/commit/c5d61a5e93dc7753a3059c5b3ea7f37ed21fef3a) | `deliantra-server: init at 3.1`                                                |
| [`17325b20`](https://github.com/NixOS/nixpkgs/commit/17325b20e67ddee7f34d4776a4d8a765e2a02ba4) | `perlPackages.Deliantra: init at 2.01`                                         |
| [`9a8e5e3b`](https://github.com/NixOS/nixpkgs/commit/9a8e5e3b673e146975706df6cbea4560769dc93b) | `perlPackages.CoroEV: init at 6.55`                                            |
| [`420757f9`](https://github.com/NixOS/nixpkgs/commit/420757f99a2c370d3c30afa5a8640c1973e30daf) | `perlPackages.AnyEventIRC: init at 0.97`                                       |
| [`c1a23272`](https://github.com/NixOS/nixpkgs/commit/c1a2327239bf0a9c9b50492fb035318f700af156) | `perlPackages.AnyEventBDB: init at 1.1`                                        |
| [`6247f09c`](https://github.com/NixOS/nixpkgs/commit/6247f09c49a7ae2c5e63b9f4a14bc6b4a34b4081) | `perlPackages.ObjectEvent: init at 1.23`                                       |
| [`5c6349c2`](https://github.com/NixOS/nixpkgs/commit/5c6349c21f855b543fe089666d9c3fe51836f298) | `perlPackages.CompressLZF: init at 3.8`                                        |
| [`cc829e36`](https://github.com/NixOS/nixpkgs/commit/cc829e3655258d84106ffbb14f2d63033d1f37cb) | `perlPackages.BDB: init at 1.92`                                               |
| [`f3ea275c`](https://github.com/NixOS/nixpkgs/commit/f3ea275c672a0af90309c85108169dd9cb65c628) | `perlPackages.DigestMD5: init at 2.55`                                         |
| [`10005589`](https://github.com/NixOS/nixpkgs/commit/10005589c301e9f2168492491b2748ebdda49b57) | `blitz: reinstate at 1.0.1`                                                    |