### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46ff1961227eb9ff16875b48f4e3562497d0f0e7",
-        "sha256": "035nk778lx2dpx1spy8k8blan2768kd1px6znvxql096l5jsmqfc",
+        "rev": "a54d2e72e282f2bc68c49f82c735cf664244ec75",
+        "sha256": "0wvd7s75ilbi7c91sp850l8akfkx70jd0yk7hc2r0v3hcyzf8ldw",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/46ff1961227eb9ff16875b48f4e3562497d0f0e7.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a54d2e72e282f2bc68c49f82c735cf664244ec75.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`12c65922`](https://github.com/NixOS/nixpkgs/commit/12c6592208ce632106b76c975789c617552547e6) | `adguardhome: 0.105.2 -> 0.106.3`                                      |
| [`556dcbe5`](https://github.com/NixOS/nixpkgs/commit/556dcbe51db6d9e7452bf211baf5e731554a0258) | `python3Packages.orjson: init at 3.6.3 (#137969)`                      |
| [`f13c1d94`](https://github.com/NixOS/nixpkgs/commit/f13c1d948a41d338127284670576c144c6656258) | `cargo-spellcheck: init at 0.8.13`                                     |
| [`cdd4d1ce`](https://github.com/NixOS/nixpkgs/commit/cdd4d1ceec76d727118ccec610832b7ba3e51de0) | `vector: disable flaky test`                                           |
| [`52187777`](https://github.com/NixOS/nixpkgs/commit/5218777714a09597ae3c35c94ee2096425266f1c) | `gitoxide: 0.7.0 -> 0.8.4`                                             |
| [`e98e088d`](https://github.com/NixOS/nixpkgs/commit/e98e088d4af3c41bf1a79d7135a360a0120f55d2) | `kubernetes: 1.22.1 -> 1.22.2`                                         |
| [`aa0b3b20`](https://github.com/NixOS/nixpkgs/commit/aa0b3b200df99315e55bea3357151705e11025cb) | `vimPlugins: update`                                                   |
| [`1623e435`](https://github.com/NixOS/nixpkgs/commit/1623e435dd72ee71b33f2b9b7f70de3b1a0350db) | `tree-sitter: update grammars`                                         |
| [`e2600d44`](https://github.com/NixOS/nixpkgs/commit/e2600d4430f60f31b38c6164b6241b5ba742836a) | `tree-sitter-zig: switch to a maintained version`                      |
| [`bebdf982`](https://github.com/NixOS/nixpkgs/commit/bebdf9820cfc6da1bc1061c479440d65756e81ff) | `tree-sitter-vim: init`                                                |
| [`527933a7`](https://github.com/NixOS/nixpkgs/commit/527933a7d87a712f3b1568cb69db5e3f01494f57) | `tree-sitter-rst: init`                                                |
| [`b7fb2794`](https://github.com/NixOS/nixpkgs/commit/b7fb2794c4d45653027c4b2e3fb4f23dd8914112) | `tree-sitter-elisp: init`                                              |
| [`5d087332`](https://github.com/NixOS/nixpkgs/commit/5d087332634f434165c25cc06068f782638d740d) | `tree-sitter-dart: init`                                               |
| [`19bd423f`](https://github.com/NixOS/nixpkgs/commit/19bd423fadd91b900899959038cf7f6471434dcd) | `tree-sitter-clojure: init`                                            |
| [`ed55c1a4`](https://github.com/NixOS/nixpkgs/commit/ed55c1a44435d36eb4e35da67d0f1faa6e423f04) | `mmv-go: 0.1.3 -> 0.1.4`                                               |
| [`a53e02e3`](https://github.com/NixOS/nixpkgs/commit/a53e02e3ec3fa770e9449924c45fe99bc10a1cda) | `apache-jena-fuseki: 3.13.1 -> 4.2.0`                                  |
| [`f54d2792`](https://github.com/NixOS/nixpkgs/commit/f54d2792e0bbfcd31900fd4a22cdd977d5bafad8) | `apache-jena: 3.7.0 -> 4.2.0`                                          |
| [`b098f6ff`](https://github.com/NixOS/nixpkgs/commit/b098f6ff0dd77083617be628f26fbd78bdd598c0) | `memorymapping: constrain to darwin (fails on linux) (#138404)`        |
| [`8b749d81`](https://github.com/NixOS/nixpkgs/commit/8b749d8134347a814cd023f18c5b0bc327e1d1da) | `vimPlugins.vim-clap: fix cargoSha256`                                 |
| [`ef448795`](https://github.com/NixOS/nixpkgs/commit/ef448795997dd7bde63cdb1a50413e3f0f855af6) | `phoronix-test-suite: run missing hooks: preInstall, postInstall`      |
| [`a34f7dbb`](https://github.com/NixOS/nixpkgs/commit/a34f7dbb73831240702c1f60ca24e6f856622575) | `chromiumDev: fix build`                                               |
| [`ffb2d26c`](https://github.com/NixOS/nixpkgs/commit/ffb2d26c36b83a5a1070018fb54625f86167858d) | `vscode-extensions.justusadam.language-haskell: 3.2.1 -> 3.40`         |
| [`d7b1157b`](https://github.com/NixOS/nixpkgs/commit/d7b1157b9bf0956397d8fbcced3fe2370db36e21) | `vscode-extensions.haskell.haskell: 1.10 -> 1.61`                      |
| [`a92dd171`](https://github.com/NixOS/nixpkgs/commit/a92dd171bae2db6eeff74a3d31fa99e47e793359) | `catatonit: 0.1.5 -> 0.1.6`                                            |
| [`0fd8cc39`](https://github.com/NixOS/nixpkgs/commit/0fd8cc390806ef15ded043e729816faa277120af) | `treewide: switch from pantheon.maintainers to lib.teams.pantheon`     |
| [`70da1764`](https://github.com/NixOS/nixpkgs/commit/70da17646624c7d24daacc644c3c870a938b2f94) | `atftp: enable tests`                                                  |
| [`10842338`](https://github.com/NixOS/nixpkgs/commit/108423388944d94a080fc5f04f213777f78f11b1) | `atftp: 0.7.4 -> 0.7.5`                                                |
| [`f126efd8`](https://github.com/NixOS/nixpkgs/commit/f126efd820273736a7910777641e4ed5563ba091) | `nixos/pantheon-tweaks: init`                                          |
| [`0dcac759`](https://github.com/NixOS/nixpkgs/commit/0dcac759f29b5bd983f2bda424c081aa71b04875) | `nixos/dokuwiki: Add support for Caddy web server`                     |
| [`dde5b46c`](https://github.com/NixOS/nixpkgs/commit/dde5b46c5abd66198e56149157e591ae9d729707) | `pantheon-tweaks: init at 1.0.1`                                       |
| [`647a5f63`](https://github.com/NixOS/nixpkgs/commit/647a5f636b225ed996966d5c38763c43f6f40e8a) | `pyradio: moved package folder`                                        |
| [`fe296b79`](https://github.com/NixOS/nixpkgs/commit/fe296b79b4c803fec51410a987a11f077715a845) | `materialize: 0.8.3 -> 0.9.4`                                          |
| [`af5ba65b`](https://github.com/NixOS/nixpkgs/commit/af5ba65b9f4b9fee755fb6701400b7d61d1804e3) | `nixos/nntp-proxy: define group, fix after #133166`                    |
| [`fa3664a1`](https://github.com/NixOS/nixpkgs/commit/fa3664a176b36d731b5673d5674a8b81229acce1) | `nixos/logcheck: define group, fix after #133166`                      |
| [`cd2b24c3`](https://github.com/NixOS/nixpkgs/commit/cd2b24c3060bbe5173a746b34da3c61799c5e8d7) | `nixos/heapster: define group, fix after #133166`                      |
| [`9e94e48b`](https://github.com/NixOS/nixpkgs/commit/9e94e48b9487281bebd37a8f2696f7b6f88240fb) | `nixos/gammu-smsd: define group, fix after #133166`                    |
| [`ca2db671`](https://github.com/NixOS/nixpkgs/commit/ca2db671badf066911a3805bf00e5c3adce66909) | `nixos/cgminer: define group, fix eval after #133166`                  |
| [`3e9520f4`](https://github.com/NixOS/nixpkgs/commit/3e9520f414e438b5f4911838713e34d11268163f) | `nixos/cgminer: fix type of services.cgminer.config option`            |
| [`8c2e6705`](https://github.com/NixOS/nixpkgs/commit/8c2e6705b38182cbe1f2fb1e460e7b7d26d75b46) | `nixos/gpsd: define group, fix after #133166`                          |
| [`615db90f`](https://github.com/NixOS/nixpkgs/commit/615db90f3db73ebe5bef1bab3f1fca90a6cbe521) | `nixos/openntpd, nixos/ntp: define group, fix after #133166`           |
| [`88b4ba21`](https://github.com/NixOS/nixpkgs/commit/88b4ba2169994650aabdd7591a6bfd70fb187690) | `nixos/unifi: define group, fix after #133166`                         |
| [`1b01b72d`](https://github.com/NixOS/nixpkgs/commit/1b01b72d85d78a4f586a35a141d062939682e897) | `maintainers: add iagoq`                                               |
| [`ab5e9ceb`](https://github.com/NixOS/nixpkgs/commit/ab5e9cebcd1b1a18412f25518407421e20114034) | `monitor: 0.8.1 -> 0.9.5`                                              |
| [`663b56ef`](https://github.com/NixOS/nixpkgs/commit/663b56eff099eaa2b0efa4ec5b2a2d6cc1ed09a0) | `procdump: 1.1.1 -> 1.2`                                               |
| [`a1ac5195`](https://github.com/NixOS/nixpkgs/commit/a1ac5195b2e8536d1d35ded33d33c3f5730a086a) | `pleroma: 2.4.0 -> 2.4.1`                                              |
| [`fd010f6b`](https://github.com/NixOS/nixpkgs/commit/fd010f6ba6c46f29d0606d1abce268c92d639c94) | `autorestic: init at 1.2.0`                                            |
| [`1b16dbeb`](https://github.com/NixOS/nixpkgs/commit/1b16dbeb557c0016d070687a296f0afe37b540b9) | `nixos/rl-2111: mention pantheon 6 upgrade and touchegg module`        |
| [`49988059`](https://github.com/NixOS/nixpkgs/commit/49988059476e53a3d1cf4c41f4186f3cb2396d04) | `nixos/pantheon: prefer pantheon.epiphany`                             |
| [`dc19457a`](https://github.com/NixOS/nixpkgs/commit/dc19457a80ba0c7c871d832f60dbf7c3cfbff2a1) | `nixos/pantheon: remove lightlocker`                                   |
| [`15818140`](https://github.com/NixOS/nixpkgs/commit/158181403aee2bc9bc93137802f335c172f3d16d) | `nixos/pantheon: enable touchegg by default`                           |
| [`b420199b`](https://github.com/NixOS/nixpkgs/commit/b420199b87a0572291b9bc25c36953b2b33fb246) | `nixos/pantheon: enable fwupd by default`                              |
| [`a66bcfe9`](https://github.com/NixOS/nixpkgs/commit/a66bcfe997af79d7697ae72044890e1f2ce7db73) | `nixos/pantheon: fix test command for wingpanel`                       |
| [`3f3502ca`](https://github.com/NixOS/nixpkgs/commit/3f3502ca9340246a9c00ada9ccb21bf0b7be1ab3) | `nixos/pantheon: update excludePackages example in docs`               |
| [`760f7e57`](https://github.com/NixOS/nixpkgs/commit/760f7e57e42d92f39d2b59794716e508472ec762) | `nixos/pantheon: install elementary-mail by default`                   |
| [`0366acbc`](https://github.com/NixOS/nixpkgs/commit/0366acbcd54e2e27d3a96c4cadd8aaf2f2ce12bf) | `nixos/pantheon: add inter and open-dyslexic as preinstalled font`     |
| [`2478c8bf`](https://github.com/NixOS/nixpkgs/commit/2478c8bf01cbb85ce15d32f01af053a00fd9ed82) | `nixos/touchegg: init`                                                 |
| [`fee747f5`](https://github.com/NixOS/nixpkgs/commit/fee747f5c5dc1db64c7a2805507387a85bd1c842) | `pantheon.epiphany: init`                                              |
| [`dc5ea090`](https://github.com/NixOS/nixpkgs/commit/dc5ea0908da8359383c96bfa5f8c23fd5b8308d1) | `pantheon.touchegg: init`                                              |
| [`72b2f5ab`](https://github.com/NixOS/nixpkgs/commit/72b2f5ab093f7fcae0e464c965317d5ce65eaa10) | `touchegg: 1.1.1 -> 2.0.11`                                            |
| [`5bab4543`](https://github.com/NixOS/nixpkgs/commit/5bab454300db3b4f495b986587179835aad70d2a) | `pantheon.granite: 6.1.0 -> 6.1.1`                                     |
| [`1258bfcc`](https://github.com/NixOS/nixpkgs/commit/1258bfcc496b138e638e71d624d8ed036d4f9049) | `pantheon.elementary-calculator: 1.6.2 -> 1.7.0`                       |
| [`2c3dec3e`](https://github.com/NixOS/nixpkgs/commit/2c3dec3e2d55e382ada8dd37ce0993f877836f46) | `pantheon.elementary-photos: fix translations`                         |
| [`f7b26fbe`](https://github.com/NixOS/nixpkgs/commit/f7b26fbe9aa7df40264a2da754bee74d62ed5b4d) | `pantheon.elementary-code: fix translations`                           |
| [`7627e552`](https://github.com/NixOS/nixpkgs/commit/7627e5523cca23fd0c33a4741ff1b4899cb31ae9) | `pantheon.elementary-terminal: fix translations`                       |
| [`8808680e`](https://github.com/NixOS/nixpkgs/commit/8808680e7a212bf80fc057c5766cd0de0dc3b03c) | `pantheon.elementary-videos: fix translations`                         |
| [`bdce39c9`](https://github.com/NixOS/nixpkgs/commit/bdce39c9f274d0849e0a99220e163ec07515325d) | `pantheon.appcenter: 3.6.0 -> 3.7.1`                                   |
| [`e56ee9ba`](https://github.com/NixOS/nixpkgs/commit/e56ee9ba6602c7fdf30648b4b170a06c4ad436a0) | `pantheon.elementary-feedback: 6.0.0 -> 6.1.0`                         |
| [`55236341`](https://github.com/NixOS/nixpkgs/commit/5523634193c79ccb3861e517cea5c7f31ed41397) | `pantheon.elementary-mail: 6.0.0 -> 6.1.1`                             |
| [`de73ad25`](https://github.com/NixOS/nixpkgs/commit/de73ad2567a4f445ea46b30b51ab86aa191e92e3) | `pantheon.elementary-files: 4.5.0 -> 6.0.2`                            |
| [`2cc74a21`](https://github.com/NixOS/nixpkgs/commit/2cc74a2106038356daee39062bb8b1cf0c55d488) | `pantheon.elementary-calendar: 5.1.1 -> 6.0.1`                         |
| [`91073bc8`](https://github.com/NixOS/nixpkgs/commit/91073bc810e1606a116b96c4f59c57ad7c2777f0) | `pantheon.elementary-screenshot: 1.7.1 -> 6.0.0`                       |
| [`3da8bb4e`](https://github.com/NixOS/nixpkgs/commit/3da8bb4e3a8836ca53396f52ac92998992a476e2) | `pantheon.elementary-tasks: init at 6.0.3`                             |
| [`9a630f47`](https://github.com/NixOS/nixpkgs/commit/9a630f47d8dcb543a11f273e5a37c2861497ff33) | `pantheon.elementary-camera: 1.0.6 -> 6.0.0`                           |
| [`a94ae9d2`](https://github.com/NixOS/nixpkgs/commit/a94ae9d223b2cb6430f96940404ab56805b71535) | `pantheon.elementary-gsettings-desktop-schemas: fix build`             |
| [`1558d9c1`](https://github.com/NixOS/nixpkgs/commit/1558d9c17ba53652cb779298c9bde9e00a7c754c) | `pantheon.elementary-settings-daemon: reinit at 1.0.0`                 |
| [`e9facd8a`](https://github.com/NixOS/nixpkgs/commit/e9facd8a4617897f4dc772b01459aed5d8610e9a) | `pantheon.elementary-music: 5.1.0 -> 5.1.1`                            |
| [`a13fd377`](https://github.com/NixOS/nixpkgs/commit/a13fd37777bc051dd71944e04d8de7b7649dc02b) | `pantheon.elementary-dock: unstable-2020-06-11 -> unstable-2021-07-16` |
| [`25070d7d`](https://github.com/NixOS/nixpkgs/commit/25070d7d69bd503c27a565e2970922ef12b14861) | `pantheon.sideload: 1.1.1 -> 6.0.1`                                    |
| [`2a11a3f6`](https://github.com/NixOS/nixpkgs/commit/2a11a3f6845e3b884049988406469b8ae4fd3b67) | `pantheon.pantheon-agent-polkit: 1.0.3 -> 1.0.4`                       |
| [`df45f3fc`](https://github.com/NixOS/nixpkgs/commit/df45f3fc469a876f5f33f508c65ffba975f30638) | `pantheon.pantheon-agent-geoclue2: 1.0.4 -> 1.0.5`                     |
| [`4f1ecaf4`](https://github.com/NixOS/nixpkgs/commit/4f1ecaf481e4c5bf8e3fa5990e07037a13c2283d) | `pantheon.elementary-notifications: unstable-2020-03-31 -> 6.0.0`      |
| [`c7b59807`](https://github.com/NixOS/nixpkgs/commit/c7b5980740d0192d220d7547bd8a96e300b43ce4) | `pantheon.elementary-capnet-assist: 2.2.5 -> 2.3.0`                    |
| [`a3b7f0cd`](https://github.com/NixOS/nixpkgs/commit/a3b7f0cd349ded83bc548b3970aaf88601dde91d) | `pantheon.contractor: 0.3.4 -> 0.3.5`                                  |
| [`88b3b9d8`](https://github.com/NixOS/nixpkgs/commit/88b3b9d84756245147a4f20d22816195c7b484c1) | `pantheon.elementary-shortcut-overlay: 1.1.2 -> 1.2.0`                 |
| [`891f943c`](https://github.com/NixOS/nixpkgs/commit/891f943c126815f858294ad12e2c876b259e6a74) | `pantheon.elementary-onboarding: 1.2.1 -> 6.0.0`                       |
| [`990ba078`](https://github.com/NixOS/nixpkgs/commit/990ba0785541a7a67c069a1fdbb7be7d1101090a) | `pantheon.elementary-session-settings: unstable-2020-07-06 -> 6.0.0`   |
| [`03a059f6`](https://github.com/NixOS/nixpkgs/commit/03a059f60744020ad5cf593f8855c8ebf6932a7a) | `pantheon.elementary-default-settings: 5.1.2 -> 6.0.1`                 |
| [`f7103f89`](https://github.com/NixOS/nixpkgs/commit/f7103f89272d760e3f22d969dd0b46da4388b933) | `pantheon.elementary-greeter: 5.0.4 -> 6.0.0`                          |
| [`0b44eae0`](https://github.com/NixOS/nixpkgs/commit/0b44eae0ab4c96e18693287fcfc543176e09e5c7) | `pantheon.elementary-wallpapers: 5.5.0 -> 6.0.0`                       |
| [`834e7ea0`](https://github.com/NixOS/nixpkgs/commit/834e7ea022758eeb86115d4ac9b2af65dd0ba8de) | `pantheon.elementary-gtk-theme: 5.4.2 -> 6.0.0`                        |
| [`79737143`](https://github.com/NixOS/nixpkgs/commit/7973714304f012f5ad3a991c2cdec0a8a9d6e7ac) | `pantheon.elementary-dpms-helper: drop package`                        |
| [`ceedbf92`](https://github.com/NixOS/nixpkgs/commit/ceedbf92c095f2d1943b966f0816a5e85bd82b9a) | `pantheon.gala: 3.3.2 -> 6.0.1`                                        |
| [`75473c2d`](https://github.com/NixOS/nixpkgs/commit/75473c2d7002b08e53d437f6f88c8975721834e2) | `gnome.gnome-settings-daemon338: init at 3.38.2`                       |
| [`634488aa`](https://github.com/NixOS/nixpkgs/commit/634488aa608c863fa54eaaa232024856bc3463dd) | `gnome.mutter338: 3.34.6 -> 3.38.6`                                    |
| [`798cc01d`](https://github.com/NixOS/nixpkgs/commit/798cc01d0c0834c2a2c3b923ff07917edb5703da) | `pantheon.wingpanel-indicator-sound: 2.1.6 -> 6.0.0`                   |
| [`aeeed28b`](https://github.com/NixOS/nixpkgs/commit/aeeed28b6e1b80a3b841d921c7c58c1f08b22a22) | `pantheon.wingpanel-indicator-session: unstable-2020-09-13 -> 2.3.0`   |
| [`243f51d3`](https://github.com/NixOS/nixpkgs/commit/243f51d34a0815e08ce0c4e522977294e835d3ac) | `pantheon.wingpanel-indicator-power: 2.2.0 -> 6.1.0`                   |
| [`13d1f3a0`](https://github.com/NixOS/nixpkgs/commit/13d1f3a08fa213445aed7e405c654435ca45a69c) | `pantheon.wingpanel-indicator-notifications: 2.1.4 -> 6.0.0`           |
| [`66f99d3b`](https://github.com/NixOS/nixpkgs/commit/66f99d3b61a5b852ec0b729df55cd687be417c91) | `pantheon.wingpanel-indicator-nightlight: 2.0.4 -> 2.1.0`              |
| [`e654bff6`](https://github.com/NixOS/nixpkgs/commit/e654bff699efca52d212d56e60536260ca52c528) | `pantheon.wingpanel-indicator-network: 2.2.4 -> 2.3.0`                 |
| [`3b0bf70a`](https://github.com/NixOS/nixpkgs/commit/3b0bf70af4cf2d166d60c163545b354f262bdec3) | `pantheon.wingpanel-indicator-keyboard: 2.2.1 -> 2.4.0`                |
| [`082d6d72`](https://github.com/NixOS/nixpkgs/commit/082d6d72fddbbd44540616e5f49d0a944e45797c) | `pantheon.wingpanel-indicator-datetime: 2.2.5 -> 2.3.0`                |
| [`51812f98`](https://github.com/NixOS/nixpkgs/commit/51812f981cf609179b55bd7063ae106188f64f72) | `pantheon.wingpanel-indicator-bluetooth: unstable-2020-10-01 -> 2.1.8` |
| [`840cd6ca`](https://github.com/NixOS/nixpkgs/commit/840cd6ca9f5124a890a5472e2b7df11624688588) | `pantheon.wingpanel-indicator-a11y: init at 1.0.0`                     |
| [`c752b39b`](https://github.com/NixOS/nixpkgs/commit/c752b39bcd087d67b2ad49381dc6a50f17bcef0b) | `pantheon.wingpanel-applications-menu: 2.7.1 -> 2.8.2`                 |
| [`a1447194`](https://github.com/NixOS/nixpkgs/commit/a1447194fd25eccf61a7e51d165a70ae275c2dc9) | `pantheon.wingpanel: 2.3.2 -> 3.0.0`                                   |
| [`3c244eb9`](https://github.com/NixOS/nixpkgs/commit/3c244eb96f9a0738aeb3033606b6b1fa57d5c1b2) | `pantheon.switchboard-plug-wacom: init at 1.0.0`                       |
| [`c46f5224`](https://github.com/NixOS/nixpkgs/commit/c46f52246044081ce6ffbff3f813b8a98e848a9e) | `pantheon.switchboard-plug-sound: 2.2.5 -> 2.2.7`                      |
| [`e1d417e2`](https://github.com/NixOS/nixpkgs/commit/e1d417e2541cfbed6c16ccbeb2edfac07875d28c) | `pantheon.switchboard-plug-sharing: 2.1.4 -> 2.1.5`                    |
| [`851584bf`](https://github.com/NixOS/nixpkgs/commit/851584bf17b8140afd6019dcc56b999648732817) | `pantheon.switchboard-plug-security-privacy: 2.2.4 -> 2.2.5`           |
| [`0864cb05`](https://github.com/NixOS/nixpkgs/commit/0864cb054bd3f4bcf87afc17d6a908db4382acf6) | `pantheon.switchboard-plug-printers: 2.1.9 -> 2.1.10`                  |
| [`28503b6f`](https://github.com/NixOS/nixpkgs/commit/28503b6f324bd912547c38c76e817965eb5e2979) | `pantheon.switchboard-plug-power: 2.4.2 -> 2.6.0`                      |
| [`ed744571`](https://github.com/NixOS/nixpkgs/commit/ed744571e17ef9b4dc808cf2d3db43cfd0389295) | `pantheon.switchboard-plug-pantheon-shell: 2.8.4 -> 6.0.0`             |
| [`b2292021`](https://github.com/NixOS/nixpkgs/commit/b2292021e2e64f9b7386607fb17c54ee92fabd8a) | `pantheon.switchboard-plug-onlineaccounts: 2.0.1 -> 6.2.0`             |
| [`c3e3e5c0`](https://github.com/NixOS/nixpkgs/commit/c3e3e5c0a0c19be415fe2684f4218ddd50b7c50b) | `pantheon.switchboard-plug-notifications: 2.1.7 -> 2.2.0`              |
| [`49bdb614`](https://github.com/NixOS/nixpkgs/commit/49bdb6149c0b70eca25645af40018dd824b33a13) | `pantheon.switchboard-plug-network: 2.3.2 -> 2.4.1`                    |
| [`b5fc2607`](https://github.com/NixOS/nixpkgs/commit/b5fc2607dd797dc3f673c6fcac651ad438d468cc) | `pantheon.switchboard-plug-mouse-touchpad: 2.4.2 -> 6.0.0`             |
| [`f8359434`](https://github.com/NixOS/nixpkgs/commit/f8359434e3d530b7b21eb0d80d09f2fc3924c85a) | `pantheon.switchboard-plug-keyboard: 2.4.1 -> 2.5.0`                   |
| [`c8171d00`](https://github.com/NixOS/nixpkgs/commit/c8171d00aab7f8c0bbde8956e92b81627e5fa0f8) | `pantheon.switchboard-plug-display: 2.2.2 -> 2.3.1`                    |
| [`0c600319`](https://github.com/NixOS/nixpkgs/commit/0c60031997d953f6c69b2b01849510ad938b010d) | `pantheon.switchboard-plug-datetime: 2.1.9 -> 2.2.0`                   |
| [`b7a302ef`](https://github.com/NixOS/nixpkgs/commit/b7a302ef48dc56cb5ca1d3fae1797c378dd4a960) | `pantheon.switchboard-plug-bluetooth: 2.3.2 -> 2.3.6`                  |
| [`627c9fc8`](https://github.com/NixOS/nixpkgs/commit/627c9fc86d9108f7d669641b66e45d4c46d65bc0) | `pantheon.switchboard-plug-applications: 2.1.7 -> 6.0.0`               |
| [`0f4d3a87`](https://github.com/NixOS/nixpkgs/commit/0f4d3a87b46edb704f6935c7452eba80684f5b6b) | `pantheon.switchboard-plug-about: 2.6.3 -> 6.0.1`                      |
| [`2912d592`](https://github.com/NixOS/nixpkgs/commit/2912d5927a0d0515adff0c74d76f00fc8b774e95) | `pantheon.switchboard-plug-a11y: 2.2.0 -> 2.3.0`                       |
| [`e79876b1`](https://github.com/NixOS/nixpkgs/commit/e79876b1f7f87830d7503ecb243e7c0b71652e39) | `pantheon.switchboard: 2.4.0 -> 6.0.0`                                 |
| [`9ec36def`](https://github.com/NixOS/nixpkgs/commit/9ec36def15c8dc03114e7902d650ea22ba2f5ab2) | `tar2ext4: 0.8.21 -> 0.8.22`                                           |
| [`5cd2a1c1`](https://github.com/NixOS/nixpkgs/commit/5cd2a1c1995f724405e1a5cbdc627cc6aa7185f2) | `maintainers: add renesat`                                             |
| [`f9958a83`](https://github.com/NixOS/nixpkgs/commit/f9958a835a408e575d466aa72eddc07bcc30f400) | `signal-desktop: 5.17.1 -> 5.17.2`                                     |
| [`8718a7b5`](https://github.com/NixOS/nixpkgs/commit/8718a7b5e110d1a00248253a707ef885da2f81af) | `rdkafka: 1.7.0 -> 1.8.0`                                              |
| [`2b9f9efe`](https://github.com/NixOS/nixpkgs/commit/2b9f9efeecf43555bf86c8fbf1ef6e4bc8b30b82) | `vimPlugins: use lib.getName instead of plugin.pname`                  |
| [`d9d1a11a`](https://github.com/NixOS/nixpkgs/commit/d9d1a11aed1761bc3a9d95dd2b8d154c44d4feec) | `fix: remove trailing '/.' from vim-plug plugin paths`                 |
| [`6a40706d`](https://github.com/NixOS/nixpkgs/commit/6a40706d5146a0d0567fbdea59c3d67c340b7694) | `chromiumDev: 95.0.4636.4 -> 95.0.4638.10`                             |
| [`a11784ab`](https://github.com/NixOS/nixpkgs/commit/a11784ab9ca241f9d84e098825270d6c07bb4946) | `chromiumBeta: 94.0.4606.41 -> 94.0.4606.50`                           |
| [`70e69cb1`](https://github.com/NixOS/nixpkgs/commit/70e69cb1c2b0f36e77b97536cf4f5463fc4cd7e6) | `macchina: 1.1.5 -> 1.1.6`                                             |
| [`0243f326`](https://github.com/NixOS/nixpkgs/commit/0243f3264b524358d9c58da621e46f3438378cb3) | `lima: 0.6.3 -> 0.6.4`                                                 |
| [`e14ab523`](https://github.com/NixOS/nixpkgs/commit/e14ab523730b9e5e5bf655d62aad765c24614c61) | `gpxsee: 9.5 → 9.6`                                                    |
| [`10c712ad`](https://github.com/NixOS/nixpkgs/commit/10c712ad4e964b02ff6cac3de4f7bd38218595b2) | `kubesec: 2.11.2 -> 2.11.3`                                            |
| [`483b311b`](https://github.com/NixOS/nixpkgs/commit/483b311b17efa6e42cd5a48736d6578af357bcfe) | `ocamlPackages.omd: run configure hooks`                               |
| [`16ab3254`](https://github.com/NixOS/nixpkgs/commit/16ab3254bfd2003453d0fc173e7f78b1c4f2ec62) | `python3Packages.pook: 1.0.1 -> 1.0.2`                                 |
| [`b8675c0c`](https://github.com/NixOS/nixpkgs/commit/b8675c0ca379f19b0f06eaaff9f9a69afd3ec968) | `trunk: 0.10.0 -> 0.13.1`                                              |
| [`8596bd67`](https://github.com/NixOS/nixpkgs/commit/8596bd678a7406c80ea762f332574630a513f4af) | `crowdin-cli: 3.6.5 -> 3.7.0`                                          |
| [`0aa049a1`](https://github.com/NixOS/nixpkgs/commit/0aa049a13cd3240c8aaf25018b817a50bc4a7cc0) | `tts: 0.3.0 -> 0.3.1`                                                  |
| [`693213da`](https://github.com/NixOS/nixpkgs/commit/693213da3e25d4f903c6f227c885e1e5c1cc4935) | `bosh-cli: 6.4.6 -> 6.4.7`                                             |
| [`560ce8d1`](https://github.com/NixOS/nixpkgs/commit/560ce8d15c760b16b52606a678bc861d3a8908bc) | `yt-dlp: remove obsolete `postPatch``                                  |
| [`d5069c92`](https://github.com/NixOS/nixpkgs/commit/d5069c92a2970022c858f18435d79d1ab210df4a) | `python38Packages.vidstab: 1.7.3 -> 1.7.4`                             |
| [`b4b8a83d`](https://github.com/NixOS/nixpkgs/commit/b4b8a83dfc074eb2cf7f66f22480076b8e276e9b) | `emacs.pkgs.ement: unstable-2021-09-08 -> unstable-2021-09-16`         |
| [`b81ef19d`](https://github.com/NixOS/nixpkgs/commit/b81ef19d94004db513bfb8b63d27c59f971c96f5) | `home-assistant: inherit NIX_BUILD_CORES for test suite`               |
| [`9a9f09b9`](https://github.com/NixOS/nixpkgs/commit/9a9f09b97b30db9cb4dda56313d6c9d440d006d0) | `vscode-extensions.denoland.vscode-deno: init at 3.9.1`                |
| [`3c7d0449`](https://github.com/NixOS/nixpkgs/commit/3c7d0449ad0232f18c6c1c0861316e73ebcef0d6) | `python3Packages.aiobotocore: fix build`                               |
| [`5e792015`](https://github.com/NixOS/nixpkgs/commit/5e792015a0348ad5b7f4745c5c010f7ba9f5931d) | `squeekboard: fix build with rust 1.54`                                |
| [`2cc9f0c6`](https://github.com/NixOS/nixpkgs/commit/2cc9f0c67fb11eaadbdb650db2947bf6c9eaa4ab) | `slurm: 21.08.0.1 -> 21.08.1.1`                                        |
| [`2122017a`](https://github.com/NixOS/nixpkgs/commit/2122017a114e93daf4a5681fc8fa7ab4616ec4c7) | `poco: propagate dependencies imported by CMake scripts`               |
| [`8f41eda9`](https://github.com/NixOS/nixpkgs/commit/8f41eda98b64b9cc46da12ce52bac9cc28d91dc4) | `poco: add patch to use GNUInstallDirs`                                |
| [`7696d88a`](https://github.com/NixOS/nixpkgs/commit/7696d88a4dfa02b4835358274d9a05cf1c555490) | `darktile: init at 0.0.10 (#136326)`                                   |
| [`16f424e7`](https://github.com/NixOS/nixpkgs/commit/16f424e7d2727f325168ae87ff92e69bf4ffd6bc) | `intel-gmmlib: 21.2.2 -> 21.3.1`                                       |
| [`3f953b0f`](https://github.com/NixOS/nixpkgs/commit/3f953b0f60b4c252b6a8b05de183486130ba7545) | `gdown: 3.13.0 -> 3.13.1`                                              |
| [`66e311ad`](https://github.com/NixOS/nixpkgs/commit/66e311ad696ebb7825ba40a7f5ee67323939abd2) | `vimpager: fix cross build`                                            |
| [`4467663a`](https://github.com/NixOS/nixpkgs/commit/4467663aaa4d20b329e53ebe631bd3092497c527) | `plasma-desktop: remove unneeded postPatch`                            |
| [`ef310fc7`](https://github.com/NixOS/nixpkgs/commit/ef310fc7cd755af8856af8fcbe7bbe1c08b3bc90) | `plasma-desktop: add missing dependency xf86inputlibinput for mouse`   |
| [`f837a27a`](https://github.com/NixOS/nixpkgs/commit/f837a27a8a7ae6e6bfeedc74fa6e39aea7a11f5d) | `ocaml-ng.ocamlPackages_4_13.ocaml: 4.13.0-rc1 → 4.13.0-rc2`           |
| [`662df6f4`](https://github.com/NixOS/nixpkgs/commit/662df6f4ab97ca3fd81822448def9d13e349076e) | `ansible_2_9: 2.9.25 -> 2.9.26`                                        |
| [`4156a551`](https://github.com/NixOS/nixpkgs/commit/4156a5516dd2b8ca19b5ecbf307a6024e8f4861b) | `ansible_2_10: 2.10.13 -> 2.10.14`                                     |
| [`31f932af`](https://github.com/NixOS/nixpkgs/commit/31f932af46864ad5b18d8837586b9e6b9e5f89a8) | `ansible_2_11: 2.11.4 -> 2.11.5`                                       |
| [`6cb6e67b`](https://github.com/NixOS/nixpkgs/commit/6cb6e67ba1133bbf4ce05d1b550dbc8c7140c0ae) | `ansible_2_11.collections: 4.4.0 -> 4.5.0`                             |
| [`4c313b9c`](https://github.com/NixOS/nixpkgs/commit/4c313b9cec0087c9ccef10835f30ea4e39eb982b) | `python3Packages.pypandoc: 1.6.3 -> 1.6.4`                             |
| [`f777dc4b`](https://github.com/NixOS/nixpkgs/commit/f777dc4bbefd5b704c24c1ec5c8f4ec9f1c9f71e) | `python39Packages.sphinx-argparse: 0.2.5 -> 0.3.1`                     |
| [`4e6980be`](https://github.com/NixOS/nixpkgs/commit/4e6980bee9b4e3e4e6af7626ed1dcfa1900692ff) | `python38Packages.azure-mgmt-storage: 18.0.0 -> 19.0.0`                |
| [`2f03483b`](https://github.com/NixOS/nixpkgs/commit/2f03483b816def22c0e1772e142b5e637545614d) | `python38Packages.python-sql: 1.2.2 -> 1.3.0`                          |
| [`ac02e3c7`](https://github.com/NixOS/nixpkgs/commit/ac02e3c7223d3609acf1e365955456cab8b0a081) | `python38Packages.breathe: 4.30.0 -> 4.31.0`                           |
| [`15fde52c`](https://github.com/NixOS/nixpkgs/commit/15fde52cbc8104de130460e42bd993d35979a398) | `python38Packages.ptpython: 3.0.19 -> 3.0.20`                          |
| [`cfcacac4`](https://github.com/NixOS/nixpkgs/commit/cfcacac4a978134170468f837892b3f77d220aa5) | `python3Packages.velbus-aio: init at 2021.9.1`                         |
| [`70ac11ca`](https://github.com/NixOS/nixpkgs/commit/70ac11ca8a2c036a7e0284e8a76a8297f837bfc2) | `ocrmypdf: 12.3.0 -> 12.5.0`                                           |
| [`b21ca6ae`](https://github.com/NixOS/nixpkgs/commit/b21ca6aeaee605361255803ecd38f92028bcac79) | `xh: 0.12.0 -> 0.13.0`                                                 |