### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a54d2e72e282f2bc68c49f82c735cf664244ec75",
-        "sha256": "0wvd7s75ilbi7c91sp850l8akfkx70jd0yk7hc2r0v3hcyzf8ldw",
+        "rev": "ab9569913ad347f8adcd9f80f3d14e6c26f0a1d5",
+        "sha256": "0lhzvx28fx508s82j6j9cc95ia4694cv5fiid0jskc0k9gq5rq13",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a54d2e72e282f2bc68c49f82c735cf664244ec75.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/ab9569913ad347f8adcd9f80f3d14e6c26f0a1d5.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                           |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`86682241`](https://github.com/NixOS/nixpkgs/commit/86682241081f7e291b8df454f60c0200b7f26050) | `libsixel: 1.8.6 -> 1.10.1`                                                              |
| [`bdd04def`](https://github.com/NixOS/nixpkgs/commit/bdd04deff52fd6eb0d34e08ac8193ddb96c84a96) | `meilisearch: module cleanup`                                                            |
| [`6903737a`](https://github.com/NixOS/nixpkgs/commit/6903737a8cab8e572ab28799377a28dd3785efa9) | `meilisearch: nixpkgs-fmt`                                                               |
| [`be72fadd`](https://github.com/NixOS/nixpkgs/commit/be72fadd548864f60fbb69dcb3d3b389ec79979c) | `nixosTests.meilisearch: init`                                                           |
| [`811fe35a`](https://github.com/NixOS/nixpkgs/commit/811fe35a665fa47cf88c97e9e6aa395526d3a9b6) | `nixos/meilisearch: init`                                                                |
| [`b51e8131`](https://github.com/NixOS/nixpkgs/commit/b51e813153d87636526c6ab2ca02dc3466f05a26) | `elasticsearch: support version 6`                                                       |
| [`c9845d4d`](https://github.com/NixOS/nixpkgs/commit/c9845d4d32fa4fe2b7e7c439b25b68df5dcfc005) | `cargo-dephell: init at 0.5.1`                                                           |
| [`0adf50ee`](https://github.com/NixOS/nixpkgs/commit/0adf50eefec9fb0122682a178659d6e2593f8e89) | `haskellPackages: mark builds failing on hydra as broken`                                |
| [`abbbc072`](https://github.com/NixOS/nixpkgs/commit/abbbc072b1353d8c8dbc58a6d8f3fdf83a48fa03) | `cargo-tally: init at 1.0.0`                                                             |
| [`c0423f63`](https://github.com/NixOS/nixpkgs/commit/c0423f6304aa5aec46aa3eb55b8937b4932dcf03) | `python38Packages.emoji: 1.4.2 -> 1.5.0`                                                 |
| [`aeee80f1`](https://github.com/NixOS/nixpkgs/commit/aeee80f10e1861eea15d64b3848cfb3cb343767a) | `python38Packages.databricks-connect: 8.1.12 -> 8.1.13`                                  |
| [`f5c3ef77`](https://github.com/NixOS/nixpkgs/commit/f5c3ef776243bfcbb8a00494fa6d2aa6fe7af8a2) | `python38Packages.gensim: 4.1.1 -> 4.1.2`                                                |
| [`9bc67194`](https://github.com/NixOS/nixpkgs/commit/9bc67194e06875f888bedc3bae1d1062b7a4faec) | `weechat: 3.2.1 -> 3.3`                                                                  |
| [`1ae90c51`](https://github.com/NixOS/nixpkgs/commit/1ae90c51183f3b7ac192018c17b696ef2ceedcb3) | `dhallPackages: Remove `dhall-packages` (#138487)`                                       |
| [`f0bc4d95`](https://github.com/NixOS/nixpkgs/commit/f0bc4d95b81e9b08fcdfbd96c5c6311190f2dbfe) | `pkgsStatic.toybox: fix build`                                                           |
| [`bdac6826`](https://github.com/NixOS/nixpkgs/commit/bdac6826b78c183ff2dd18e8db0b2825a60fd586) | `seatd: 0.5.0 -> 0.6.2`                                                                  |
| [`cab1a84f`](https://github.com/NixOS/nixpkgs/commit/cab1a84f28cf61d6a5c4a167afb5e712ca8d88c7) | `cargo-llvm-lines: init at 0.4.11`                                                       |
| [`b06ffb4b`](https://github.com/NixOS/nixpkgs/commit/b06ffb4b454286d71ad646fc7032942d2625f589) | `doc/rust: add missing fetchfromGitHub to derivation example`                            |
| [`73414b57`](https://github.com/NixOS/nixpkgs/commit/73414b570ad5a0e49fbe51236a3e0108710ef927) | `libdnf: switch back to default stdenv.`                                                 |
| [`1e7edcb2`](https://github.com/NixOS/nixpkgs/commit/1e7edcb21f13bfb959cf7fd0d41d52fdb9931164) | `cawbird: 1.4.1 -> 1.4.2`                                                                |
| [`248eeddc`](https://github.com/NixOS/nixpkgs/commit/248eeddcddf680b5e92c5da149db1ce7e980a2c5) | `wget: 1.21.1 -> 1.21.2`                                                                 |
| [`d0dde619`](https://github.com/NixOS/nixpkgs/commit/d0dde6199f29417aa48423644db5b259ab8dc95e) | `hck: 0.6.3 -> 0.6.4`                                                                    |
| [`cdea486e`](https://github.com/NixOS/nixpkgs/commit/cdea486e7a79995cb029ce61bbec8715572fba4d) | `cargo-diet: init at 1.2.2`                                                              |
| [`139c8fe7`](https://github.com/NixOS/nixpkgs/commit/139c8fe7055ee1788a3f2657525d41bf00cff6aa) | `elmPackages.*: auto upgrade`                                                            |
| [`cb916713`](https://github.com/NixOS/nixpkgs/commit/cb9167139eda6d4c3143d2ba1e7cf848a0a9718d) | `vmware-guest: Use vmware-vmblock-fuse for drag-and-drop synchronization (#131278)`      |
| [`88cddfbf`](https://github.com/NixOS/nixpkgs/commit/88cddfbfb5accf02f357a42835f5e7d26ca6db82) | `gocryptfs: support fstab mount`                                                         |
| [`7e399b70`](https://github.com/NixOS/nixpkgs/commit/7e399b70a70cd8ff6e15af37813edf9726d4a26b) | `exploitdb: 2021-09-17 -> 2021-09-18`                                                    |
| [`ca679942`](https://github.com/NixOS/nixpkgs/commit/ca67994224c253ac2c305392f8e58b3be78fea49) | `dua: 2.14.6 -> 2.14.7`                                                                  |
| [`242ab4de`](https://github.com/NixOS/nixpkgs/commit/242ab4debd0eca13d579d824c2d993e5ee5f0cda) | `haskell-language-server: Disable several plugin checks on arm`                          |
| [`2448e9eb`](https://github.com/NixOS/nixpkgs/commit/2448e9eb11b313c3d30626e72c4aabba83cfd69e) | `python38Packages.scikit-hep-testdata: 0.4.7 -> 0.4.8`                                   |
| [`3133899c`](https://github.com/NixOS/nixpkgs/commit/3133899cbc6a72d3a6282b46cbec465506fc2cd7) | `tailscale: 1.14.0 -> 1.14.3`                                                            |
| [`f8b837c8`](https://github.com/NixOS/nixpkgs/commit/f8b837c808490644bc7de35108a2212c22c8b262) | `ungoogled-chromium: 92.0.4515.159 -> 93.0.4577.82`                                      |
| [`0bdde7ec`](https://github.com/NixOS/nixpkgs/commit/0bdde7ecdf02f55d71792069c401fa270cf3e58c) | `haproxy: 2.3.13 -> 2.3.14`                                                              |
| [`4ec3a295`](https://github.com/NixOS/nixpkgs/commit/4ec3a29566d01b3a0ee80303a83d417c3de8ca33) | `maddy: remove maintainer (#138508)`                                                     |
| [`defe183d`](https://github.com/NixOS/nixpkgs/commit/defe183dad2ab2b419314515326bdab93d35306a) | `firejail: Remove symlink check patch`                                                   |
| [`64f5d681`](https://github.com/NixOS/nixpkgs/commit/64f5d681d95ba708afef378f86c5112798cc9039) | `nixos/physlock: fix broken wrapper`                                                     |
| [`6b84305e`](https://github.com/NixOS/nixpkgs/commit/6b84305e5cc0efe58ae3af0ba939c4f414b34305) | `python37Packages.py-air-control-exporter: 0.3.0 -> 0.3.1`                               |
| [`948ef8a6`](https://github.com/NixOS/nixpkgs/commit/948ef8a6c5fd2c71a5e45aecd5cc997740e91024) | `idris2: 0.4.0 -> 0.5.0`                                                                 |
| [`2e44a72b`](https://github.com/NixOS/nixpkgs/commit/2e44a72b8f3cd35318af1b167994f78ca259e119) | `github-backup: 0.39.0 -> 0.40.0`                                                        |
| [`70a61f29`](https://github.com/NixOS/nixpkgs/commit/70a61f2921440a913e57d99f53fd5a7fbbe2e5dd) | `awscli2: 2.2.30 -> 2.2.39`                                                              |
| [`06a91dda`](https://github.com/NixOS/nixpkgs/commit/06a91dda9cae112c32177f64df4ebfc01be934e3) | `octoprint.python.pkgs.ender3v2tempfix: init at unstable-2021-04-27`                     |
| [`e67bd161`](https://github.com/NixOS/nixpkgs/commit/e67bd161e0203b625fdf157b64dfd1730967a368) | `cicero-tui: 0.2.2 -> 0.3.0`                                                             |
| [`5ece1469`](https://github.com/NixOS/nixpkgs/commit/5ece1469136092a3509283c6d4942af2714fbca0) | `deltachat-desktop: 1.21.0 -> 1.21.1`                                                    |
| [`4bb46590`](https://github.com/NixOS/nixpkgs/commit/4bb46590541798103eef60c7cbd3d1fb24e327eb) | `home-assistant: 2021.9.6 -> 2021.9.7`                                                   |
| [`cba7d5d9`](https://github.com/NixOS/nixpkgs/commit/cba7d5d90e53094255b36816a04764a9803b4858) | `python3Packages.aioswitcher: 2.0.5 -> 2.0.6`                                            |
| [`f573a1b2`](https://github.com/NixOS/nixpkgs/commit/f573a1b2c435ee4e62edf9c24050e8674dfeafcf) | `python3Packages.plexapi: 4.7.0 -> 4.7.1`                                                |
| [`37cc6984`](https://github.com/NixOS/nixpkgs/commit/37cc698435f4546ba4ed7be972b1144bbc180816) | `python3Packages.pykodi: 0.2.5 -> 0.2.6`                                                 |
| [`54bff886`](https://github.com/NixOS/nixpkgs/commit/54bff88644a6bfa52030d4356e07d4836b249201) | `python3Packages.PyChromecast: 9.2.0 -> 9.2.1`                                           |
| [`50010c72`](https://github.com/NixOS/nixpkgs/commit/50010c72c637f8442d30ba9a0702eded422bad00) | `python3Packages.pyopenuv: 2.2.0 -> 2.2.1`                                               |
| [`3389aab8`](https://github.com/NixOS/nixpkgs/commit/3389aab889719081e240ce169ec5bc0d5ccd60d0) | `haskell.compiler.ghcjs: mark hydraPlatforms as none because output is too large`        |
| [`f65bd7a8`](https://github.com/NixOS/nixpkgs/commit/f65bd7a8a7c3af6d40d4943483e68a7b76c4c750) | `libopenmpt: default to supporting pulseaudio`                                           |
| [`88b8df5c`](https://github.com/NixOS/nixpkgs/commit/88b8df5c21b7a081a58751466da5b1b248cae68d) | `linuxPackages.bcc: fix build`                                                           |
| [`9d529893`](https://github.com/NixOS/nixpkgs/commit/9d5298933afb1ed0dcada1eed9314e470458b7f8) | `zfs: add meta.mainProgram`                                                              |
| [`5ad7db7e`](https://github.com/NixOS/nixpkgs/commit/5ad7db7ed87e03e3fbd818f05f34010ebe9636db) | `openssh: add meta.mainProgram`                                                          |
| [`14791e1d`](https://github.com/NixOS/nixpkgs/commit/14791e1debe62e94fb2e8b8c8782b085c27f0d9a) | `gnugrep: add meta.mainProgram`                                                          |
| [`501cb25e`](https://github.com/NixOS/nixpkgs/commit/501cb25ed8c5dbf37dfd4c61365d5f18f12dc0ae) | `chia: 1.2.6 -> 1.2.7`                                                                   |
| [`b6d51777`](https://github.com/NixOS/nixpkgs/commit/b6d517774cb41b6ba685223b6f7adf941b0ca26f) | `mnamer: 2.5.3 -> 2.5.4`                                                                 |
| [`cb8b9f47`](https://github.com/NixOS/nixpkgs/commit/cb8b9f47f59ec6015a022eb332f147c2a904a59a) | `conftest: 0.27.0 -> 0.28.0`                                                             |
| [`13ccdc4e`](https://github.com/NixOS/nixpkgs/commit/13ccdc4e710c5a80a5b2a2ec704d0d796b0b8504) | `vendir: 0.22.0 -> 0.23.0`                                                               |
| [`77adbb9c`](https://github.com/NixOS/nixpkgs/commit/77adbb9ce7e9f3585102d23614e7c3a596d83b71) | `maintainers/scripts/haskell/hydra-report: Add traffic light`                            |
| [`bb198385`](https://github.com/NixOS/nixpkgs/commit/bb19838557dbd643b685ef395dc93632db59718f) | `tilt: 0.22.8 -> 0.22.9`                                                                 |
| [`a0bbb9e7`](https://github.com/NixOS/nixpkgs/commit/a0bbb9e7667e10862e14056ae446a47b3c95aac7) | `zfsUnstable: correct sha256`                                                            |
| [`3fd2e2b7`](https://github.com/NixOS/nixpkgs/commit/3fd2e2b7f83a55dabfe39c7ac68e619dc216b643) | `sabnzbd: 3.3.1 -> 3.4.0`                                                                |
| [`8ba5f811`](https://github.com/NixOS/nixpkgs/commit/8ba5f8115c6a21d98213f08716aae2f386443c26) | `nixos/zope2: define group`                                                              |
| [`23d14d89`](https://github.com/NixOS/nixpkgs/commit/23d14d89b8678944f8f8211f6366bba3d54f930c) | `nixos/tvheadend: define group, fix eval after #133166`                                  |
| [`fd04a872`](https://github.com/NixOS/nixpkgs/commit/fd04a872bcc94c8eba9a34328d593e1d9d62f250) | `nixos/toxvpn: define group, fix eval after #133166`                                     |
| [`d09ab775`](https://github.com/NixOS/nixpkgs/commit/d09ab77588852a9d30e7f85f85d5266f50f59f78) | `nixos/shout: define group, fix eval after #133166`                                      |
| [`feeca7dd`](https://github.com/NixOS/nixpkgs/commit/feeca7dd55f4e793487238311261ba45baf97684) | `nixos/rippled: define group, fix eval after #133166`                                    |
| [`a654d779`](https://github.com/NixOS/nixpkgs/commit/a654d779fe57f8bcbf711353d2caa11423495506) | `nixos/ripple-data-api: define group`                                                    |
| [`6cf8b27f`](https://github.com/NixOS/nixpkgs/commit/6cf8b27fd669eb19b63d4d25acc1b08460c0dd71) | `nixos/rdnssd: define group; fix after #133166`                                          |
| [`ed2b0923`](https://github.com/NixOS/nixpkgs/commit/ed2b092333626b75e3ab70229934d576cc82a4bd) | `maintainers/scripts/haskell: Add r-deps information to build-report`                    |
| [`8aa960d5`](https://github.com/NixOS/nixpkgs/commit/8aa960d561cedb103661b64df041f88717523cdf) | `nerdctl: 0.11.1 -> 0.11.2`                                                              |
| [`b8b88612`](https://github.com/NixOS/nixpkgs/commit/b8b88612ff31b5b640d9c177c016c54d23c38983) | `haskell: update HACKING.md document to describe merge-and-open-pr.sh maintainer script` |
| [`b95e5014`](https://github.com/NixOS/nixpkgs/commit/b95e501450ee49f46456f6a91626ec168654f749) | `vimUtils.buildVimPlugin: fix cross compiles`                                            |
| [`e13d2792`](https://github.com/NixOS/nixpkgs/commit/e13d27929ce46247dccf963dd1d6226c1c2e0360) | `vim_configurable: fix cross compile`                                                    |
| [`cade060d`](https://github.com/NixOS/nixpkgs/commit/cade060da3482363560d6890efd1c9e2fcc54beb) | `vim: remove unneeded cross flag`                                                        |
| [`ecce26dd`](https://github.com/NixOS/nixpkgs/commit/ecce26dd5aef112994caf31642200e6fdd3f2d46) | `haskell: Add a maintainer script for opening a new haskell-updates PR`                  |
| [`27873366`](https://github.com/NixOS/nixpkgs/commit/27873366b9536b892e16c477abd38c68accfda46) | `smartdns: Fix systemd service`                                                          |
| [`9ea37743`](https://github.com/NixOS/nixpkgs/commit/9ea377439ed377d61f9aad1df7e93ee3164beccd) | `thunderbird: 91.1.0 -> 91.1.1`                                                          |
| [`a4b769cb`](https://github.com/NixOS/nixpkgs/commit/a4b769cb8b4d0aa10c0b494b3d35fb2524dceba6) | `calamares: 3.2.42 -> 3.2.43`                                                            |
| [`d71129e1`](https://github.com/NixOS/nixpkgs/commit/d71129e1af35fb3975d6c7ac5607561452b68216) | `haskell.packages.ghc901.haskell-language-server: Fix build`                             |
| [`dd2d99ca`](https://github.com/NixOS/nixpkgs/commit/dd2d99cab705641876d3f76fb5ea01f9aa6abb0b) | `qv2ray: 2.6.3 -> 2.7.0`                                                                 |
| [`d9b9e0f9`](https://github.com/NixOS/nixpkgs/commit/d9b9e0f9ae8467f1a3de21320bd791516aae9de9) | `haskellPackages.haskell-language-server: Use default plugin set`                        |
| [`325e25e0`](https://github.com/NixOS/nixpkgs/commit/325e25e0ca74d40d7e8ede93e534e85e8031a671) | `haskellPackages.hls-stylish-haskell-plugin: Jailbreak to fix build`                     |
| [`48b1bb48`](https://github.com/NixOS/nixpkgs/commit/48b1bb4867cbd8f95fe5ca6aac692c290125e3b2) | `haskellPackages: regenerate package set based on current config`                        |
| [`548e93f7`](https://github.com/NixOS/nixpkgs/commit/548e93f7a1337d48241c9f097549772d65cd7afa) | `all-cabal-hashes: 2021-09-10T22:56:58Z -> 2021-09-17T18:08:40Z`                         |
| [`164ccf3d`](https://github.com/NixOS/nixpkgs/commit/164ccf3d60b715c54d8b14689ba6e4eb90f4f17e) | `haskellPackages: stackage-lts 18.9 -> 18.10`                                            |
| [`88917249`](https://github.com/NixOS/nixpkgs/commit/88917249ba2694a06d2a2e4e3e0de0eb15d20a49) | `ruffle: nightly-2021-05-14 -> nightly-2021-09-17`                                       |
| [`52cb4bd6`](https://github.com/NixOS/nixpkgs/commit/52cb4bd6a220156ba0a1d0561c57e7470fb1e84e) | `terragrunt: 0.31.11 -> 0.32.2`                                                          |
| [`9d721859`](https://github.com/NixOS/nixpkgs/commit/9d721859ebc195814b376efe46b6e1a79daca080) | `skaffold: 1.31.0 -> 1.32.0`                                                             |
| [`ff95c481`](https://github.com/NixOS/nixpkgs/commit/ff95c481e6bd4ff1b72d8ff606629bbd906cc102) | `python3Packages.zeroconf: 0.36.2 -> 0.36.4`                                             |
| [`4a978be0`](https://github.com/NixOS/nixpkgs/commit/4a978be0f16dc68cea959a0ad55de10b8e0dbd9c) | `thunderbird-bin: 91.1.0 -> 91.1.1`                                                      |
| [`37c32f26`](https://github.com/NixOS/nixpkgs/commit/37c32f26b8da2f8052fa76289c45c0a5b909e922) | `flyctl: 0.0.238 -> 0.0.240`                                                             |
| [`c256b391`](https://github.com/NixOS/nixpkgs/commit/c256b391faa0d8de851abba043cfb12478615ca9) | `erigon: 2021.08.05 -> 2021.09.02`                                                       |
| [`01889691`](https://github.com/NixOS/nixpkgs/commit/018896912ac2f7eba0863067345920948922ca53) | `teleport: 7.1.0 -> 7.1.2`                                                               |
| [`cee18277`](https://github.com/NixOS/nixpkgs/commit/cee18277c6531babefc157c813154890c293e18e) | `sjasmplus: 1.18.2 -> 1.18.3`                                                            |
| [`d303157b`](https://github.com/NixOS/nixpkgs/commit/d303157b6d01c234595d23759f06c706b992fa02) | `py-spy: 0.3.8 -> 0.3.9`                                                                 |
| [`8e2b07b4`](https://github.com/NixOS/nixpkgs/commit/8e2b07b401333f3ee083f4d0ac718bc721c5d280) | `mlvwm: 0.9.3 -> 0.9.4`                                                                  |
| [`94f77502`](https://github.com/NixOS/nixpkgs/commit/94f775024eec2cdf676ad1017a58660619fb3dd0) | `Opensnitch: Add module`                                                                 |
| [`b417e6ec`](https://github.com/NixOS/nixpkgs/commit/b417e6ec80a331403d8e6d4228ca5c60535c1056) | `ristate: init at unstable-2021-09-10`                                                   |
| [`4c3d4d96`](https://github.com/NixOS/nixpkgs/commit/4c3d4d963b2e34829182e735c685ea14c9645e54) | `intensity-normalization: init at 2.0.1`                                                 |
| [`2739ab54`](https://github.com/NixOS/nixpkgs/commit/2739ab54fbd496298a435a5d1aedfed80e0c56d6) | `python3Packages.scikit-fuzzy: unstable-2020-10-03 -> unstable-2021-03-31`               |
| [`7d8d6e8e`](https://github.com/NixOS/nixpkgs/commit/7d8d6e8e406c943a5fea1a803cc840380aa5ae19) | `cataclysm-dda: 0.F-1 -> 0.F-2`                                                          |
| [`6def1716`](https://github.com/NixOS/nixpkgs/commit/6def171697d2804b55b3959c53b02c153e888022) | `i2pd: 2.38.0 -> 2.39.0`                                                                 |