### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6b683c0527a7f777b5f2b4db2555891cd5a85f5",
-        "sha256": "0mkinbg2s4mg1ngh773h7rqc898siyigwy2wfz8jaai8k9srpx1n",
+        "rev": "d30701f2f17c18ca3096327dea5a6d09e26e8721",
+        "sha256": "1yr92z54rp8rkf29d6cp7kwc2gsf2dvfj1c1gr6yw95g37120gbs",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d6b683c0527a7f777b5f2b4db2555891cd5a85f5.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d30701f2f17c18ca3096327dea5a6d09e26e8721.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`d30701f2`](https://github.com/NixOS/nixpkgs/commit/d30701f2f17c18ca3096327dea5a6d09e26e8721) | `nixos/opensmtpd: Add missing brackets in config (#138989)`                    |
| [`80ea69bd`](https://github.com/NixOS/nixpkgs/commit/80ea69bdc8b45f0b0f7d22a2beca539d6d384d8f) | `linode-cli: add updateScript (#138547)`                                       |
| [`27ee8262`](https://github.com/NixOS/nixpkgs/commit/27ee8262e7e224abd92024ba7829d84e79c179ca) | `argyllcms: delete gcc5 patch`                                                 |
| [`13001b44`](https://github.com/NixOS/nixpkgs/commit/13001b44dc931626cb6d2faa14265b0012658e57) | `ptcollab: 0.4.2 -> 0.4.3`                                                     |
| [`fb7c5674`](https://github.com/NixOS/nixpkgs/commit/fb7c56741159ff7e38c1b16b459874b8ec02d1a1) | `python3Packages.velbus-aio: 2021.9.1 -> 2021.9.2`                             |
| [`4f5c95bb`](https://github.com/NixOS/nixpkgs/commit/4f5c95bba176ec54d5bccc678e9944bc54d5cc10) | `python38Packages.check-manifest: 0.46 -> 0.47`                                |
| [`2e4ab911`](https://github.com/NixOS/nixpkgs/commit/2e4ab91111f40a72765eda1731286bab3d7d0185) | `cliphist: init at 0.1.0`                                                      |
| [`27d1ef1c`](https://github.com/NixOS/nixpkgs/commit/27d1ef1c95eee199c6c4bb066868911c38fe3cd2) | `msmtp: 1.8.15 -> 1.8.16`                                                      |
| [`a22f2688`](https://github.com/NixOS/nixpkgs/commit/a22f2688941dd02a69cc422ba349e80030cd474f) | `discord: 0.0.15 → 0.0.16`                                                     |
| [`5ffdc31f`](https://github.com/NixOS/nixpkgs/commit/5ffdc31f6202c18484b1eb8e68a195589b92ea96) | `i2p: get rid of duplicate Java Service Wrapper`                               |
| [`b45b1d64`](https://github.com/NixOS/nixpkgs/commit/b45b1d643907e5a323d712cddab49f1988b0f97f) | `cargo-watch: 8.1.0 -> 8.1.1`                                                  |
| [`baa87c22`](https://github.com/NixOS/nixpkgs/commit/baa87c223357179c1ad2f2eae30ea4b5ce48334f) | `python3Packages.wsgiprox: init at 1.5.2`                                      |
| [`883874f5`](https://github.com/NixOS/nixpkgs/commit/883874f5131c5d936de68b5ebef7b56f8dc4f24f) | `sparse: 0.5.0 -> 0.6.3 and fixes`                                             |
| [`b98dc164`](https://github.com/NixOS/nixpkgs/commit/b98dc16457efffa9bd4141369f57ad5358c53bef) | `maintainers: add jkarlson`                                                    |
| [`946a529b`](https://github.com/NixOS/nixpkgs/commit/946a529bb913c0182ff3ddd5bd5febdfca1aff8b) | `ledger-live-desktop: 2.32.1 -> 2.33.1`                                        |
| [`399f6dda`](https://github.com/NixOS/nixpkgs/commit/399f6ddab42def8c320a665bc63c08bae4404656) | `rust-code-analysis: init at 0.0.23`                                           |
| [`c9520b0d`](https://github.com/NixOS/nixpkgs/commit/c9520b0d1abf8605c9049f387e57579ff9f7c950) | `home-assistant: test maxcube component`                                       |
| [`dc08bc82`](https://github.com/NixOS/nixpkgs/commit/dc08bc825801858d43f261b2462bd0685aba8729) | `home-assistant: update component packages`                                    |
| [`bc68bde9`](https://github.com/NixOS/nixpkgs/commit/bc68bde9740191cb04027133112c7b824ce3dc30) | `python3Packages.maxcube-api: init at 0.4.3`                                   |
| [`240faba8`](https://github.com/NixOS/nixpkgs/commit/240faba8b9ce8356ea77f835b764ea4e11ac0151) | `git-machete: fix tests`                                                       |
| [`4226cedf`](https://github.com/NixOS/nixpkgs/commit/4226cedf26c6d1bb24523fbfced700c8906ed126) | `uqm-3dovideo: switch to fetchFromGitHub`                                      |
| [`cfaa89b0`](https://github.com/NixOS/nixpkgs/commit/cfaa89b03ba45b142be130d79de9fb6b8d2e0154) | `openssh-portable: switch to fetchFromGitHub`                                  |
| [`02c1bcfc`](https://github.com/NixOS/nixpkgs/commit/02c1bcfc38d961203c39d6c2f07f7700ccc526e1) | `tracebox: switch to fetchFromGitHub`                                          |
| [`51aa71bf`](https://github.com/NixOS/nixpkgs/commit/51aa71bffb699ba086161379f05a80f0eecb4274) | `tcptraceroute: switch to fetchFromGitHub`                                     |
| [`95222c9d`](https://github.com/NixOS/nixpkgs/commit/95222c9d85b9972222cce0d4515c168e3933ef4f) | `sipsakw: switch to fetchFromGitHub`                                           |
| [`3ef5a889`](https://github.com/NixOS/nixpkgs/commit/3ef5a889f58b2889c7028018b84f9bce7df1c514) | `jbig2enc: switch to fetchFromGitHub`                                          |
| [`fd0cbc69`](https://github.com/NixOS/nixpkgs/commit/fd0cbc696a6cf96ec8d0de7f67e44d51debf782e) | `bcache-tools: switch to fetchFromGitHub`                                      |
| [`00482255`](https://github.com/NixOS/nixpkgs/commit/004822554c840c322153770381d90969be9a2d93) | `zbackup: switch to fetchFromGitHub`                                           |
| [`797843e4`](https://github.com/NixOS/nixpkgs/commit/797843e42b22856f3513be6bfb4e9d89368fb40b) | `wal-e: switch to fetchFromGitHub`                                             |
| [`3dd8b136`](https://github.com/NixOS/nixpkgs/commit/3dd8b1366ecdb2122d3e253464306f6b3cc7b198) | `dir2opus: switch to fetchFromGitHub`                                          |
| [`4a6c33d2`](https://github.com/NixOS/nixpkgs/commit/4a6c33d2ba7d7b6d51085fa5e976f1b61d87bc44) | `stuntrally: switch to fetchFromGitHub`                                        |
| [`6d9eed42`](https://github.com/NixOS/nixpkgs/commit/6d9eed42d997e605f657a049c7e3a31b66777afc) | `pkgsStatic.redis: fix build`                                                  |
| [`d4214c4d`](https://github.com/NixOS/nixpkgs/commit/d4214c4d800c625148ad936e1428d609afcb09a5) | `sile: 0.11.1 → 0.12.0`                                                        |
| [`bcd383fd`](https://github.com/NixOS/nixpkgs/commit/bcd383fdee2ae76372cfe55b0babd76a1d17d831) | `argyllcms: 2.2.0 -> 2.2.1`                                                    |
| [`5abd562a`](https://github.com/NixOS/nixpkgs/commit/5abd562a1867c0f77de2531d652c24f709ed86e8) | `nixos/kubernetes: fix deprecation warning`                                    |
| [`3cd2a403`](https://github.com/NixOS/nixpkgs/commit/3cd2a4032b5e03763a3e8989a618b97561733ec9) | `linux: 5.4.147 -> 5.4.148`                                                    |
| [`6e149861`](https://github.com/NixOS/nixpkgs/commit/6e1498613f9599e880e1e432fe13a05f451dba6b) | `linux: 5.14.6 -> 5.14.7`                                                      |
| [`afc93c11`](https://github.com/NixOS/nixpkgs/commit/afc93c11bb1004269981e3e6a42b4e182217a59b) | `linux: 5.10.67 -> 5.10.68`                                                    |
| [`217af323`](https://github.com/NixOS/nixpkgs/commit/217af32349606039bde34df4891c5ebbbd87d356) | `linux: 4.9.282 -> 4.9.283`                                                    |
| [`0931ea2b`](https://github.com/NixOS/nixpkgs/commit/0931ea2be7af1cc91c387e36be128759fb66ff68) | `linux: 4.4.283 -> 4.4.284`                                                    |
| [`9eddcf0c`](https://github.com/NixOS/nixpkgs/commit/9eddcf0c15ccc2a85ff9d0465782f7046ea8ef01) | `linux: 4.19.206 -> 4.19.207`                                                  |
| [`1e54b5a2`](https://github.com/NixOS/nixpkgs/commit/1e54b5a2fc900c2545e0075da1764a3f23c43f7e) | `linux: 4.14.246 -> 4.14.247`                                                  |
| [`22d05f8f`](https://github.com/NixOS/nixpkgs/commit/22d05f8fa2bb4ed7d6371dd3d1b7b21c28c78f27) | `nixos/plotinus: fix evaluation`                                               |
| [`a8576d40`](https://github.com/NixOS/nixpkgs/commit/a8576d4053a1bd5789748090aef475ff958627b4) | `nixos/tests/mpv: remove deprecated mpv-with-scripts`                          |
| [`cbd515e4`](https://github.com/NixOS/nixpkgs/commit/cbd515e44cd3990d2bed07ebc487b38701755ae7) | `nixos/tests/atop: remove top-level string`                                    |
| [`699b8d67`](https://github.com/NixOS/nixpkgs/commit/699b8d671da815a5105529da405b0b4de2a8a0a0) | `nixos/tests/wasabibackend: fix bitcoind config`                               |
| [`8f7978fb`](https://github.com/NixOS/nixpkgs/commit/8f7978fb9f2b34b9340cd8227354dab63a935bb5) | `kubescape: 1.0.77 -> 1.0.85`                                                  |
| [`6a814b8b`](https://github.com/NixOS/nixpkgs/commit/6a814b8ba8237c91141b5fc0e1b1e5309b9aa9c1) | `python3Packages.cmd2: add license`                                            |
| [`a124ea43`](https://github.com/NixOS/nixpkgs/commit/a124ea43a1ef3de7918ac24d03ae57db72ca5271) | `java-service-wrapper: 3.5.45 -> 3.5.46`                                       |
| [`5b0a3115`](https://github.com/NixOS/nixpkgs/commit/5b0a3115c8ee42494ae0580b50702e090a017446) | `doc: rust: rephrase paragraph about `cargoLock.lockFileContents``             |
| [`47716842`](https://github.com/NixOS/nixpkgs/commit/4771684208a6beed8293baabfdaac103552614e7) | `doc: rust: simplify snippet`                                                  |
| [`4ab63a8c`](https://github.com/NixOS/nixpkgs/commit/4ab63a8ca8883b05d0895df59e26e5e62c4a9ff8) | `doc: rust: improve clarity of example snippet`                               |
| [`4ecb3e87`](https://github.com/NixOS/nixpkgs/commit/4ecb3e87958eb65ce8c5dc07ed3c5c1d79af98f0) | `doc: rust: document cargoLock.lockFileContents`                               |
| [`f59c8627`](https://github.com/NixOS/nixpkgs/commit/f59c862770b68756f3248b85870fc2179e2a4c82) | `nixos/safeeyes: add `safeeyes` to the global path`                            |
| [`693ccbac`](https://github.com/NixOS/nixpkgs/commit/693ccbac67ceeb2cfee41529a5596ef6c528f286) | `nixos/safeeyes: add `alsa-utils` for `aplay` to the service's path`           |
| [`fa7c1141`](https://github.com/NixOS/nixpkgs/commit/fa7c1141966f830153f65355b69d177bdfb4b5cf) | `safeeyes: install .desktop file and icons`                                    |
| [`df49f656`](https://github.com/NixOS/nixpkgs/commit/df49f6565ca0039da31d0c34bec9320bfbfec535) | `nixos/tests/pantheon: fix missing lib`                                        |
| [`e39bc2d9`](https://github.com/NixOS/nixpkgs/commit/e39bc2d9af19bf99628f59b8c7d370c7c3973d23) | `electron_12: 12.1.1 -> 12.1.2`                                                |
| [`c744ecb6`](https://github.com/NixOS/nixpkgs/commit/c744ecb69fe7ec6b0d07697a782a61873148c184) | `nixos/tests/systemd-networkd-ipv6-prefix-delegation: fix wrapper`             |
| [`b53a5b91`](https://github.com/NixOS/nixpkgs/commit/b53a5b91b98dd6669c45a0d9c539f210a3f34558) | `nixos/atop: fix broken wrapper`                                               |
| [`19662101`](https://github.com/NixOS/nixpkgs/commit/196621010c23b201735881a8512abf6a1999d037) | `nixos/tests/mariadb-galera-rsync: fix nogroup`                                |
| [`113cc7b1`](https://github.com/NixOS/nixpkgs/commit/113cc7b13614a6228dc5b4edab117a162e05f68a) | `nixos/tests/mariadb-galera-mariabackup: fix nogroup`                          |
| [`96dc04e9`](https://github.com/NixOS/nixpkgs/commit/96dc04e9330c0ba7bb0c7aa8cf4cca75966305a3) | `tlsh: 4.5.0 -> 4.9.3 (#138639)`                                               |
| [`20ad6696`](https://github.com/NixOS/nixpkgs/commit/20ad669618616588089013e48a0b9d61aea09611) | `nixos/tests/minio: fix deprecation warning`                                   |
| [`87d76b17`](https://github.com/NixOS/nixpkgs/commit/87d76b1783f5c34c2402a8d9c635341e011df220) | `nixos/tests/mysql: fix nogroup`                                               |
| [`08cd8667`](https://github.com/NixOS/nixpkgs/commit/08cd8667eeef874dc99c2d0f5ecdb88d6f454a14) | `nixos: filalex77 -> Br1ght0ne`                                                |
| [`1f55c7e0`](https://github.com/NixOS/nixpkgs/commit/1f55c7e02213082673f7b6d09a1efaf16be5a794) | `nixos/tests: drop latestKernel.hardened`                                      |
| [`88b3c29c`](https://github.com/NixOS/nixpkgs/commit/88b3c29cf1ddb7582b11d89af16b750e44b5bc67) | `nixos: heimdalFull -> heimdal`                                                |
| [`3f109249`](https://github.com/NixOS/nixpkgs/commit/3f10924949681e88220394a4e3604b327f876e39) | `nixos/flannel: pkgs.etcdctl -> pkgs.etcd`                                     |
| [`1f826a71`](https://github.com/NixOS/nixpkgs/commit/1f826a71645203bbf6f6f6ec0d5e6973d7f0464a) | `nixos/tests/ec2: fix conflicting option values`                               |
| [`e2a66822`](https://github.com/NixOS/nixpkgs/commit/e2a668224fbd0a577bcf5a89d9e10a95cceeffc3) | `nixos/tests/enlightenment: fix renamed options`                               |
| [`56ad0a49`](https://github.com/NixOS/nixpkgs/commit/56ad0a49c83eabac02a4c4a24dc01bfb4f6681dc) | `nixos/dnscrypt-wrapper: fix nogroup`                                          |
| [`b51ce741`](https://github.com/NixOS/nixpkgs/commit/b51ce741065958799177dc8aaef1a2b7cde4731a) | `python3Packages.notus-scanner: init at unstable-2021-09-05`                   |
| [`59c890f1`](https://github.com/NixOS/nixpkgs/commit/59c890f14b64dfef14d711d662291a0408528824) | `python3Packages.bitlist: allow later parts releases`                          |
| [`7284b144`](https://github.com/NixOS/nixpkgs/commit/7284b144fdd9a697d02d2d58273be986c5327437) | `python3Packages.parts: 1.0.3 -> 1.1.0`                                        |
| [`cf8ce8f2`](https://github.com/NixOS/nixpkgs/commit/cf8ce8f269d2fb2ab17bf280ccc11f9120d59bfc) | `python3Packages.pyspnego: 0.1.6 -> 0.2.0`                                     |
| [`6a76b842`](https://github.com/NixOS/nixpkgs/commit/6a76b842b36d6c4ddf0789eb1cf1aeb0bc4d4905) | `tytools: init at 0.9.3 (#138799)`                                             |
| [`b8779dbf`](https://github.com/NixOS/nixpkgs/commit/b8779dbffebde9eaba8a80a5505ce04876f13d09) | `nim: fix power arch predicates`                                               |
| [`abc00fd6`](https://github.com/NixOS/nixpkgs/commit/abc00fd6bd7d81af4b86a1f2dc88432326dc9021) | `buildah: 1.22.3 -> 1.23.0`                                                    |
| [`616690dc`](https://github.com/NixOS/nixpkgs/commit/616690dc6439e315da12523f3cc1602939f6364e) | `samba: 4.14.7 -> 4.15.0`                                                      |
| [`80b3ac2f`](https://github.com/NixOS/nixpkgs/commit/80b3ac2f65d085812e4cf7105daf108ade2bf4b9) | `python38Packages.google-resumable-media: 2.0.2 -> 2.0.3`                      |
| [`88e3f207`](https://github.com/NixOS/nixpkgs/commit/88e3f20774ec11ba7e7b0dc72ab7cef77198b955) | `svgbob: 0.5.4 -> 0.6.2`                                                       |
| [`169cd512`](https://github.com/NixOS/nixpkgs/commit/169cd512d4cf2ec70e4631e7e4d89677a3cf262c) | `nixos/tests/cntr: fix evaluation`                                             |
| [`78b0883e`](https://github.com/NixOS/nixpkgs/commit/78b0883e2f6838907e51055be8cb7db49310aafb) | `nixos/tests/prometheus-exporters: fix nogroup`                                |
| [`5b4f8afa`](https://github.com/NixOS/nixpkgs/commit/5b4f8afae40cdbea52a8256d772c0795dd938351) | `nixos/tests: stdenv.lib -> lib`                                               |
| [`137a4f7b`](https://github.com/NixOS/nixpkgs/commit/137a4f7b438ca5debef83c8ccb60f6ad9f5ffaf9) | `svtplay-dl: 4.3 -> 4.5`                                                       |
| [`d4640395`](https://github.com/NixOS/nixpkgs/commit/d4640395ac2f677d0543a77461d16f6910bd812e) | `gnome.tali: 40.2 -> 40.3`                                                     |
| [`c117f55e`](https://github.com/NixOS/nixpkgs/commit/c117f55ee223b5e4c865c9f848e9effa395f58ac) | `exploitdb: 2021-09-21 -> 2021-09-22`                                          |
| [`722a4c1a`](https://github.com/NixOS/nixpkgs/commit/722a4c1a54b93a5f12cb8aa9ce7f61c03dc09276) | `telegraf: 1.19.3 -> 1.20.0`                                                   |
| [`1a922bc8`](https://github.com/NixOS/nixpkgs/commit/1a922bc8d670e6638248bacd0cf82698e0bc6fc2) | `python38Packages.google-cloud-dns: 0.33.0 -> 0.33.1`                          |
| [`add19802`](https://github.com/NixOS/nixpkgs/commit/add1980208df72b706901d1f6331131b37b2badc) | `du-dust: 0.6.2 -> 0.7.5`                                                      |
| [`455c8b51`](https://github.com/NixOS/nixpkgs/commit/455c8b51a9208c5025a02955a03eb62c7942dac6) | `dolt: 0.27.4.2 -> 0.28.4`                                                     |
| [`22aa7416`](https://github.com/NixOS/nixpkgs/commit/22aa741604b4f4c01b6c0cceb66e3b81293a5d33) | `dnsproxy: 0.39.5 -> 0.39.7`                                                   |
| [`97567fcb`](https://github.com/NixOS/nixpkgs/commit/97567fcbdcff14235a7fc349a19de99e8712bca9) | `pantheon.appcenter: 3.7.1 -> 3.8.0`                                           |
| [`0e4230f1`](https://github.com/NixOS/nixpkgs/commit/0e4230f1bd2f65e12ac8bcd5995035991edea58c) | `deno: 1.14.0 -> 1.14.1`                                                       |
| [`69a7a1e1`](https://github.com/NixOS/nixpkgs/commit/69a7a1e1a19e56cdda8031bdc25f41418a6d7280) | `python38Packages.google-crc32c: 1.1.3 -> 1.2.0`                               |
| [`32b32117`](https://github.com/NixOS/nixpkgs/commit/32b32117b0cccb37b1629e26082fb700754cd3ec) | `python38Packages.google-cloud-speech: 2.8.0 -> 2.9.0`                         |
| [`b483ef3c`](https://github.com/NixOS/nixpkgs/commit/b483ef3cc866ae6afed65115ba6f0c6b19efce49) | `btrfs-progs: 5.13.1 -> 5.14.1`                                                |
| [`394ef2f8`](https://github.com/NixOS/nixpkgs/commit/394ef2f868c77973680fef03fca2628a122021af) | `python38Packages.google-cloud-runtimeconfig: 0.32.4 -> 0.32.5`                |
| [`ad24dc7a`](https://github.com/NixOS/nixpkgs/commit/ad24dc7a2d4c9c42309d0046a6465053eeb44b5d) | `python38Packages.google-cloud-spanner: 3.9.0 -> 3.10.0`                       |
| [`0abcbe93`](https://github.com/NixOS/nixpkgs/commit/0abcbe93cb387dce5031125231ea1c8e2dc415f8) | `vultr-cli: 2.8.2 -> 2.8.3`                                                    |
| [`7dd6d9a8`](https://github.com/NixOS/nixpkgs/commit/7dd6d9a8c168edd95a692f490222a1521c63edba) | `oil: 0.9.0 -> 0.9.2`                                                          |
| [`0170ff4c`](https://github.com/NixOS/nixpkgs/commit/0170ff4c9598c0a01d687d5241198b0a78debfd7) | `conftest: 0.28.0 -> 0.28.1`                                                   |
| [`000ae671`](https://github.com/NixOS/nixpkgs/commit/000ae67128762df86cfac70b242d7e0894db9ffb) | `k3s: add updateScript`                                                        |
| [`89e1b623`](https://github.com/NixOS/nixpkgs/commit/89e1b6235802043d4a9200b40990c0bf1b236942) | `cloudflared: 2021.9.0 -> 2021.9.1`                                            |
| [`f0380192`](https://github.com/NixOS/nixpkgs/commit/f0380192311f0d907290e80e8fee4895640b942b) | `vieb: 6.0.0 -> 6.1.0`                                                         |
| [`0978fb74`](https://github.com/NixOS/nixpkgs/commit/0978fb7417aab7465b0fa18df30d5991bec4a558) | `wike: 1.5.6 -> 1.5.7`                                                         |
| [`81d51629`](https://github.com/NixOS/nixpkgs/commit/81d51629fdee89af0e9f4271755bdad67ecceaea) | `cargo-watch: 8.0.0 -> 8.1.0`                                                  |
| [`5d3f726f`](https://github.com/NixOS/nixpkgs/commit/5d3f726f0bab0fc367b30f6183a80542bdc5bd84) | `yq-go: 4.13.0 -> 4.13.2`                                                      |
| [`2c1fc116`](https://github.com/NixOS/nixpkgs/commit/2c1fc1165ef7d42a9bcec2106864ae7daa499a66) | `cargo-supply-chain: fix darwin build`                                         |
| [`769f21d0`](https://github.com/NixOS/nixpkgs/commit/769f21d0d6952229d5035718279367fe70f2406a) | `cargo-play: enable most of the tests`                                         |
| [`55bf4e27`](https://github.com/NixOS/nixpkgs/commit/55bf4e27c4035760fbb78fb16d95382acd8a3cef) | `fits-cloudctl: set meta.mainProgram`                                          |
| [`8eb28bed`](https://github.com/NixOS/nixpkgs/commit/8eb28bed2ffd9bbba0ab81f9ae0178639fb406b2) | `1password: Install polkit action file (#132478)`                              |
| [`3ce63d43`](https://github.com/NixOS/nixpkgs/commit/3ce63d43b38751253453c6c7236468ed1655a8ba) | `aws-workspaces: 3.1.8.1198 -> 4.0.1.1302`                                     |
| [`5740fd7f`](https://github.com/NixOS/nixpkgs/commit/5740fd7f8982141636235fc0dc94828048c1a46f) | `vimPlugins.vim-textobj-entire: init at 2018-01-19`                            |
| [`277d3f65`](https://github.com/NixOS/nixpkgs/commit/277d3f6545cc887519dc70c58452ffa7ff545c62) | `vimPlugins.vim-fubitive: init at 2020-09-10`                                  |
| [`325c47d0`](https://github.com/NixOS/nixpkgs/commit/325c47d00e30d4dd21128f231dba34ffefd4489c) | `vimPlugins.vifm-vim: init at 2021-09-21`                                      |
| [`89fcf1d6`](https://github.com/NixOS/nixpkgs/commit/89fcf1d62e5dee7b43818bb1d5f9c542f0718a44) | `vimPlugins.slimv: init at 2021-08-24`                                         |
| [`0bc25f85`](https://github.com/NixOS/nixpkgs/commit/0bc25f85706f376f95fc63d599c2a3c23c1e9661) | `vimPlugins.presenting-vim: init at 2021-06-02`                                |
| [`e09f3a16`](https://github.com/NixOS/nixpkgs/commit/e09f3a16975495451c9c88a306e9f6e515691ada) | `vimPlugins: update`                                                           |
| [`f18dd09f`](https://github.com/NixOS/nixpkgs/commit/f18dd09fc2e0dfac0418f40f4c56fbb97d0ef5c4) | `aws-workspaces: only leave wrapper script in bin`                             |
| [`a35c2235`](https://github.com/NixOS/nixpkgs/commit/a35c2235b79c59bfea8a86fb95919e450ce23409) | `panamax: init at 1.0.3`                                                       |
| [`8d8b451f`](https://github.com/NixOS/nixpkgs/commit/8d8b451f725b63edec06b033ff2bdaa2f0885b4e) | `chromium: 93.0.4577.82 -> 94.0.4606.54`                                       |
| [`56d99a73`](https://github.com/NixOS/nixpkgs/commit/56d99a735113e48d2ea51084804c5a59c5603a5f) | `chromiumDev: 95.0.4638.10 -> 95.0.4638.17`                                    |
| [`ecca3b5e`](https://github.com/NixOS/nixpkgs/commit/ecca3b5e19756c46f7a510fee3ba656e718b5a4f) | `glitter: init at 1.4.4`                                                       |
| [`c0d5bb2a`](https://github.com/NixOS/nixpkgs/commit/c0d5bb2ab4fb3e72c82a417fcfd6d7e6927d4ffa) | `python3Packages.angrop: 9.0.9947 -> 9.0.10010`                                |
| [`4c2aa4f9`](https://github.com/NixOS/nixpkgs/commit/4c2aa4f9745145c1b1bdec8a51e3b56d581d3478) | `python3Packages.angr: 9.0.9947 -> 9.0.10010`                                  |
| [`75fa7b14`](https://github.com/NixOS/nixpkgs/commit/75fa7b1418796f2410550d975b57ffa449b68554) | `python3Packages.cle: 9.0.9947 -> 9.0.10010`                                   |
| [`702360fc`](https://github.com/NixOS/nixpkgs/commit/702360fc8b254b9725075942c19289fd987b61dd) | `python3Packages.claripy: 9.0.9947 -> 9.0.10010`                               |
| [`15c3fa1d`](https://github.com/NixOS/nixpkgs/commit/15c3fa1d844e7ae760aeb043ac065643f3bb104e) | `python3Packages.pyvex: 9.0.9947 -> 9.0.10010`                                 |
| [`7ee75928`](https://github.com/NixOS/nixpkgs/commit/7ee75928144f19cbe22d4142dbd14880d6693733) | `python3Packages.ailment: 9.0.9947 -> 9.0.10010`                               |
| [`7f1e75ab`](https://github.com/NixOS/nixpkgs/commit/7f1e75abccc7aa4af502afe9c3d97d9c5d285e72) | `python3Packages.archinfo: 9.0.9947 -> 9.0.10010`                              |
| [`f661c05a`](https://github.com/NixOS/nixpkgs/commit/f661c05a11fe2984ecf8e2c50274ad58f9e301a6) | `heisenbridge: 1.1.1 -> 1.1.2`                                                 |
| [`ccb944e5`](https://github.com/NixOS/nixpkgs/commit/ccb944e58aa542e03d469296b284f00c6bb61e07) | `rhack: init at 0.1.0`                                                         |
| [`a8b29bdb`](https://github.com/NixOS/nixpkgs/commit/a8b29bdb273f2f460c3f44cfaddb08fd6a79bdde) | `gitea: 1.15.2 -> 1.15.3`                                                      |
| [`8ef4b639`](https://github.com/NixOS/nixpkgs/commit/8ef4b6397f96934a8e0cbc9712ef85431d325f99) | `rust-script: init at 0.17.0`                                                  |
| [`9955eced`](https://github.com/NixOS/nixpkgs/commit/9955ecedec80099f29236341bb1d0fd678c6202a) | `python3Packages.plyer: init at 2.0.0 (#136902)`                               |
| [`89393893`](https://github.com/NixOS/nixpkgs/commit/89393893ec3ef669d06217ed98d54034118c5734) | `tauon: add optional withDiscordRPC (#138765)`                                 |
| [`c95fcfc6`](https://github.com/NixOS/nixpkgs/commit/c95fcfc6b3d2b02a2a8295d39460b05e4b0a221e) | `libfabric: meta.platforms = lib.platforms.all and 1.13.0 -> 1.13.1 (#138780)` |
| [`13bb5bc9`](https://github.com/NixOS/nixpkgs/commit/13bb5bc9473fc313f4ecb6d1bf3a1e841c45a90e) | `weechatScripts.edit: init at 1.0.2 (#135786)`                                 |
| [`016f9cf6`](https://github.com/NixOS/nixpkgs/commit/016f9cf6b52030da3385e87df00e3057dfbaed55) | `cargo-supply-chain: init at 0.0.2`                                            |