### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "841b22ab76741eb4d2edcb48117a688e7d7f1b24",
-        "sha256": "1jqr2x8sphppm8n8r49wdhqqsdfq3cqa0hmr4rai6j08gqcxnq0a",
+        "rev": "d0220562772b787d58c48df3434f36da1f552bdc",
+        "sha256": "1nhh4afidrq7crb82ax3f5gqn17scxi7rl6zlxnzcplnwr0waczq",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/841b22ab76741eb4d2edcb48117a688e7d7f1b24.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d0220562772b787d58c48df3434f36da1f552bdc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                              |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`447e08c3`](https://github.com/NixOS/nixpkgs/commit/447e08c3dad83341f5c7473ab229e29f8aa129cc) | `sleuthkit: add build for JNI libraries`                                                    |
| [`7fdded5c`](https://github.com/NixOS/nixpkgs/commit/7fdded5cd04540832738d2d440d8e876bff3e982) | `nodePackages.browser-sync: init at 2.27.5`                                                 |
| [`25c840ed`](https://github.com/NixOS/nixpkgs/commit/25c840ed1bde9516670c591e31c4acdf660e9425) | `cloak: init at 0.2.0`                                                                      |
| [`7b6eb919`](https://github.com/NixOS/nixpkgs/commit/7b6eb919617de0b184618df9cbf2d108b01abd06) | `align: init at 1.1.3`                                                                      |
| [`b27698e0`](https://github.com/NixOS/nixpkgs/commit/b27698e075a2d8a9670adf51e98917a35f11392e) | `python3Packages.APScheduler: fix build`                                                    |
| [`c415f709`](https://github.com/NixOS/nixpkgs/commit/c415f70996c99be6cb916a70fc4dba2647933ea2) | `tv: 0.6.0 -> 0.7.0`                                                                        |
| [`15bb3ac5`](https://github.com/NixOS/nixpkgs/commit/15bb3ac5a92552e1264bb457084eea72b263e179) | `chromium: 94.0.4606.54 -> 94.0.4606.61`                                                    |
| [`b9468515`](https://github.com/NixOS/nixpkgs/commit/b9468515932d827651838700969fc6b415590af0) | `chromiumBeta: 94.0.4606.54 -> 95.0.4638.17`                                                |
| [`10770653`](https://github.com/NixOS/nixpkgs/commit/10770653d783ace820726977433e23526bae31e7) | `sks: remove myself as maintainer`                                                          |
| [`61a7f5f9`](https://github.com/NixOS/nixpkgs/commit/61a7f5f90d93dda7cce27836295288cc0bd9a3f6) | `iproute_mptcp: Fix the build`                                                              |
| [`d49c3d09`](https://github.com/NixOS/nixpkgs/commit/d49c3d09bebeec287bb53c4cb020de299ed280f2) | `python38Packages.awscrt: 0.12.2 -> 0.12.3`                                                 |
| [`e36f885a`](https://github.com/NixOS/nixpkgs/commit/e36f885a098825a0228a7967b312873f08a6916e) | `rstudio: remove ehmry from maintainers`                                                    |
| [`25f627ea`](https://github.com/NixOS/nixpkgs/commit/25f627eaac5ae4a386b397cb56e5e572c53b2c4c) | `python38Packages.mypy-boto3-s3: 1.18.46 -> 1.18.47`                                        |
| [`bda03add`](https://github.com/NixOS/nixpkgs/commit/bda03add2bcd6ee6406daea4783000d26dcd0c56) | `python3Packages.fountains: 0.2.1 -> 1.0.0`                                                 |
| [`74890343`](https://github.com/NixOS/nixpkgs/commit/74890343e45aac498f881fa8a51e19a9456b5141) | `python3Packages.bitlist: 0.4.0 -> 0.5.1`                                                   |
| [`4f8b48e4`](https://github.com/NixOS/nixpkgs/commit/4f8b48e432d37b4bda1013ca99aab702e6138aac) | `texlive.bin.core: remove format -> engine links (#136293)`                                 |
| [`39e8ec2d`](https://github.com/NixOS/nixpkgs/commit/39e8ec2db68b863543bd377e44fbe02f8d05864e) | `maintainers/scripts/rebuild-amount.sh: report parallelism, add example, cleanup (#137695)` |
| [`affa5e38`](https://github.com/NixOS/nixpkgs/commit/affa5e384f151cf79aa935397f4d56d64bf86f8f) | `python3Packages.pysyncobj: 0.3.8 -> 0.3.10`                                                |
| [`5b1ce387`](https://github.com/NixOS/nixpkgs/commit/5b1ce387db813d0378a6f9c4e096ebf280a01bcc) | `python3Packages.adjusttext: add doCheck`                                                   |
| [`2588a5f6`](https://github.com/NixOS/nixpkgs/commit/2588a5f650dfa43c30f81a5c00ed2cc396c65c9a) | `python3Packages.python-http-client: 3.3.2 -> 3.3.3`                                        |
| [`3a758199`](https://github.com/NixOS/nixpkgs/commit/3a75819912b12ad308a6a19cd9356c2553603505) | `Bump pytorch-bin to 1.9.1`                                                                 |
| [`48216e46`](https://github.com/NixOS/nixpkgs/commit/48216e46892917b05e9f2ee9033e0b0b5d3a6375) | `slack: 4.18.0 -> 4.19.x`                                                                   |
| [`e31a829e`](https://github.com/NixOS/nixpkgs/commit/e31a829e26d63cda34aaabe0fb6d6074cf05e58f) | `python38Packages.hvac: 0.11.0 -> 0.11.2`                                                   |
| [`dbb297ba`](https://github.com/NixOS/nixpkgs/commit/dbb297ba7a56cb784f98acfec5b0624deb6a9aa1) | `ryujinx: 1.0.6954 -> 1.0.7047`                                                             |
| [`e3f9cf25`](https://github.com/NixOS/nixpkgs/commit/e3f9cf25e126c1aeaec41994a08c5137be151636) | `python38Packages.youtube-search-python: 1.4.7 -> 1.4.8`                                    |
| [`bd0701bf`](https://github.com/NixOS/nixpkgs/commit/bd0701bf3d4684677d3d1875e00b2febfc4d9a0f) | `python38Packages.APScheduler: 3.7.0 -> 3.8.0`                                              |
| [`d7bba45c`](https://github.com/NixOS/nixpkgs/commit/d7bba45c605304637d77269dfa5ddb0b30b96eee) | `python38Packages.simple-salesforce: 1.11.3 -> 1.11.4`                                      |
| [`dc7bf062`](https://github.com/NixOS/nixpkgs/commit/dc7bf06273869392f8a2c20cee8696eff4478b5c) | `python38Packages.robotframework-requests: 0.9.1 -> 0.9.2`                                  |
| [`ccfdf4e5`](https://github.com/NixOS/nixpkgs/commit/ccfdf4e538e8c1ab3a36c4592a4fe07cb608bebf) | `python38Packages.snowflake-connector-python: 2.6.0 -> 2.6.1`                               |
| [`cd4782bc`](https://github.com/NixOS/nixpkgs/commit/cd4782bc2fb62dc63fca3581d4af4324b07166cf) | `python38Packages.sphinxcontrib_httpdomain: 1.7.0 -> 1.8.0`                                 |
| [`9564ca51`](https://github.com/NixOS/nixpkgs/commit/9564ca5147358d74a6da0b6c9117e4e265ed1b77) | `python38Packages.transmission-rpc: 3.2.7 -> 3.2.8`                                         |
| [`24cd5844`](https://github.com/NixOS/nixpkgs/commit/24cd58440a06e79b7f8cd019f897c83abf56ddc9) | `python38Packages.toonapi: 0.2.0 -> 0.2.1`                                                  |
| [`34611790`](https://github.com/NixOS/nixpkgs/commit/346117904c6b2167ea602d47fd87a75063646cb2) | `python38Packages.tinydb: 4.5.1 -> 4.5.2`                                                   |
| [`1f2047b3`](https://github.com/NixOS/nixpkgs/commit/1f2047b3fa4ac99da16be1d286d7c5fbee589ec5) | `cargo-supply-chain: 0.0.2 -> 0.2.0`                                                        |
| [`6adf8ac2`](https://github.com/NixOS/nixpkgs/commit/6adf8ac2815e1e58a1ada7b72be46303abefc4d0) | `pantheon.elementary-photos: 2.7.1 -> 2.7.2`                                                |
| [`7dd555c5`](https://github.com/NixOS/nixpkgs/commit/7dd555c5acff8266b7e2cf7b84dc4ede4aff70fe) | `pantheon.gala: 6.0.1 -> 6.2.0`                                                             |
| [`24a85509`](https://github.com/NixOS/nixpkgs/commit/24a855097a7632e967852b1cbb70bb4b392acc2f) | `python3Packages.hiyapyco: allow later Jinja2 releases`                                     |
| [`912ee876`](https://github.com/NixOS/nixpkgs/commit/912ee876da7b92c2b298933abb2012c8f293a17c) | `Remove trailing whitespace`                                                                |
| [`ef950ca2`](https://github.com/NixOS/nixpkgs/commit/ef950ca2fd023e82dcede72c60e6c4b866c85440) | `python38Packages.r2pipe: 1.6.0 -> 1.6.2`                                                   |
| [`2417378e`](https://github.com/NixOS/nixpkgs/commit/2417378e35e5c4083c312ed78f8c9c6155483302) | `python38Packages.pytwitchapi: 2.3.0 -> 2.4.2`                                              |
| [`05cacac3`](https://github.com/NixOS/nixpkgs/commit/05cacac35c8f3778d157c8d5f3f8c1f253401f48) | `vimPlugins.vim-qlist: init at 2019-07-18`                                                  |
| [`7d9bcf3e`](https://github.com/NixOS/nixpkgs/commit/7d9bcf3e877edad1b9e7a9c68e9c8970e1b2bf00) | `vimPlugins.vim-argwrap: init at 2021-06-11`                                                |
| [`4b321e22`](https://github.com/NixOS/nixpkgs/commit/4b321e220446ca7ab05805a1e84f54d8d82bc357) | `python3Packages.censys: 2.0.7 -> 2.0.8`                                                    |
| [`7b401b2b`](https://github.com/NixOS/nixpkgs/commit/7b401b2b302ee798d86cf0d6d086253da595a333) | `vimPlugins.vim-argumentative: init at 2014-11-24`                                          |
| [`917fa7ae`](https://github.com/NixOS/nixpkgs/commit/917fa7aeff1e708c8309086bffe68a69de2d3c67) | `python3Packages.pontos: switch to poetry-core`                                             |
| [`924cbbd2`](https://github.com/NixOS/nixpkgs/commit/924cbbd2fdbd3bdb0f4c79d34ff0933d60b08f66) | `privacyidea: explicitly use fetchPypi in flask-migrate override`                           |
| [`38d1ee33`](https://github.com/NixOS/nixpkgs/commit/38d1ee33e9998ae5e2636fa558a4f770b7824069) | `python3Packages.flask-migrate: fix build`                                                  |
| [`f4db4059`](https://github.com/NixOS/nixpkgs/commit/f4db40591019666f0821e36ee3f9023ab122bcfa) | `python3Packages.priority: fix build, refactor package`                                     |
| [`c9dcfe33`](https://github.com/NixOS/nixpkgs/commit/c9dcfe33a8f008b11e0276e4f2d0649e172034cc) | `python3Packages.openshift: relax kubernetes constraint`                                    |
| [`bf2a7163`](https://github.com/NixOS/nixpkgs/commit/bf2a71631fdeb5719492bfeaf9f0fca6170f2c2e) | `python3Packages.kubernetes: fix build, refactor`                                           |
| [`75fec749`](https://github.com/NixOS/nixpkgs/commit/75fec7494be462a771e5697af71b8644cb8521c6) | `python38Packages.pybullet: 3.1.8 -> 3.1.9`                                                 |
| [`2169cfd8`](https://github.com/NixOS/nixpkgs/commit/2169cfd85284126b61e89ef03468f5078a8acc79) | `auto-cpufreq: fix version output`                                                          |
| [`889dba01`](https://github.com/NixOS/nixpkgs/commit/889dba01cce5ea45a2bd733f671eee7cb6818cff) | `python38Packages.pontos: 21.9.0 -> 21.9.1`                                                 |
| [`c743750a`](https://github.com/NixOS/nixpkgs/commit/c743750aca50ad71c284993cf2a75dd88b7a8215) | `python38Packages.pikepdf: 3.0.0 -> 3.1.0`                                                  |
| [`6219c9b3`](https://github.com/NixOS/nixpkgs/commit/6219c9b363e2c06378cbca5b55e0acd109540864) | `python38Packages.parts: 1.1.0 -> 1.1.2`                                                    |
| [`e1c56ff2`](https://github.com/NixOS/nixpkgs/commit/e1c56ff290fe78847082dacc1ea33aaa564e2098) | `python3Packages.auth0-python: 3.17.0 -> 3.18.0`                                            |
| [`beea0747`](https://github.com/NixOS/nixpkgs/commit/beea07475e02a11915181f352500b818999601cd) | `python3Packages.biplist: diasble failing tests`                                            |
| [`49ec311b`](https://github.com/NixOS/nixpkgs/commit/49ec311b53db1d5cc7e452b06d8a8d3e55b60fb3) | `python38Packages.mypy-boto3-s3: 1.18.29 -> 1.18.46`                                        |
| [`89d061ac`](https://github.com/NixOS/nixpkgs/commit/89d061aca1e673cb9ad4c5709a192ac670f01daf) | `python38Packages.mocket: 3.9.44 -> 3.10.0`                                                 |
| [`9f07894e`](https://github.com/NixOS/nixpkgs/commit/9f07894ef01700ca8f36f76b0a27fc686e45326a) | `python38Packages.mne-python: 0.23.3 -> 0.23.4`                                             |
| [`a34d3583`](https://github.com/NixOS/nixpkgs/commit/a34d3583930abb8b6a26012d68c3471ecd8e1d32) | `python38Packages.mechanize: 0.4.6 -> 0.4.7`                                                |
| [`f0f08efd`](https://github.com/NixOS/nixpkgs/commit/f0f08efd5f0f0a81d8cd4ef916690dd3c7d2e95d) | `meli: alpha-0.6.2 -> alpha-0.7.1`                                                          |
| [`02b6fe2c`](https://github.com/NixOS/nixpkgs/commit/02b6fe2cb20a1a520c49504c4c6afde37863829e) | `python38Packages.labgrid: 0.3.3 -> 0.4.0`                                                  |
| [`5a99313d`](https://github.com/NixOS/nixpkgs/commit/5a99313dcb2b9004a770d32cbc563c49aeb1d5e0) | `python38Packages.jupyterlab_server: 2.7.2 -> 2.8.1`                                        |
| [`f199e6ef`](https://github.com/NixOS/nixpkgs/commit/f199e6ef4edb71bbaab8f229665f11d1590d7b1a) | `python38Packages.jupyterlab: 3.1.9 -> 3.1.13`                                              |
| [`f933c683`](https://github.com/NixOS/nixpkgs/commit/f933c68374b9c6195dc74d26c95fc9bf240fead8) | `discourse: enable restoring backups bigger than RAM`                                       |
| [`bda29935`](https://github.com/NixOS/nixpkgs/commit/bda29935b32ab777318c1fc4e0bfb6fd5156d2f5) | `deltachat-desktop: 1.22.1 -> 1.22.2`                                                       |
| [`d6e60ba7`](https://github.com/NixOS/nixpkgs/commit/d6e60ba7ebb12dabd4230e4e358a16c763348b36) | `python38Packages.jdatetime: 3.6.2 -> 3.6.4`                                                |
| [`68a8d864`](https://github.com/NixOS/nixpkgs/commit/68a8d86415c3de64a9ba311058bdb8fda7f930dd) | `es *beat6: Fix build on aarch64`                                                           |
| [`912de509`](https://github.com/NixOS/nixpkgs/commit/912de5092f72f86692595e6bc2537cf66cbc8fee) | `{lib-}mediainfo: 21.03 -> 21.09`                                                           |
| [`bbdb3460`](https://github.com/NixOS/nixpkgs/commit/bbdb34607e3e9ab51ded51526335b3e347961357) | `kubernetes-helm: 3.6.3 -> 3.7.0`                                                           |
| [`c1bdd547`](https://github.com/NixOS/nixpkgs/commit/c1bdd547f753624308b60ae067b715914f53f24e) | `gdu: 5.7.0 -> 5.8.0`                                                                       |
| [`220f1573`](https://github.com/NixOS/nixpkgs/commit/220f1573eda50e5c872cb8b754c50bd09778f7b0) | `pantheon.wingpanel-indicator-sound: pin vala version`                                      |
| [`a1efffc3`](https://github.com/NixOS/nixpkgs/commit/a1efffc3836fd3578fdc61b8352e27244953cfd3) | `xandikos: disable failing tests`                                                           |
| [`cc887542`](https://github.com/NixOS/nixpkgs/commit/cc8875421b922e8f50cebe6b03e8eb4ddae59739) | `pantheon.switchboard-plug-mouse-touchpad: remove fetchpatch from input`                    |
| [`2f04ac85`](https://github.com/NixOS/nixpkgs/commit/2f04ac8561df0a8ace7b9bffebc99b5de3eb2c86) | `heisenbridge: 1.1.2 -> 1.2.0`                                                              |
| [`3c6559d6`](https://github.com/NixOS/nixpkgs/commit/3c6559d673b374d7420f13469860e41b34f131c2) | `panthoen.elementary-greeter: remove fetchpatch from input`                                 |
| [`fa24e51b`](https://github.com/NixOS/nixpkgs/commit/fa24e51b723072180c3c9bb7a8c0af42286401fe) | `pantheon.switchboard-plug-keyboard: remove fetchpatch from input`                          |
| [`56d9b433`](https://github.com/NixOS/nixpkgs/commit/56d9b433368cf65bc2a0d238a4b0701508f5bef1) | `tix: fix build on darwin`                                                                  |
| [`f1977801`](https://github.com/NixOS/nixpkgs/commit/f197780161cc7c5f339cfbca3b71905727e64b24) | `python3Packages.atenpdu: 0.3.1 -> 0.3.2`                                                   |
| [`b1ff8d9e`](https://github.com/NixOS/nixpkgs/commit/b1ff8d9eedd24d5a993d86c9f71e4151022a129b) | `python3Packages.sendgrid: 6.8.1 -> 6.8.2`                                                  |
| [`08f7638f`](https://github.com/NixOS/nixpkgs/commit/08f7638f9685a320169802147e9eae073e216c8d) | `python3Packages.gradient: mark as broken`                                                  |
| [`a86e1f5d`](https://github.com/NixOS/nixpkgs/commit/a86e1f5dac8aac6629cacc9ccf99725d082e1f02) | `tk: fix missing definition in macOS header`                                                |
| [`fde56dbd`](https://github.com/NixOS/nixpkgs/commit/fde56dbdcfba6548ff6d900ba7d956f3f8cae8a7) | `python38Packages.deemix: 3.4.4 -> 3.5.1`                                                   |
| [`448721e3`](https://github.com/NixOS/nixpkgs/commit/448721e39c8449ee7bb12eb32cc8bff4278df9d4) | `firefox-unwrapped: 92.0 -> 92.0.1`                                                         |
| [`d9eefb5d`](https://github.com/NixOS/nixpkgs/commit/d9eefb5d67b16a488bef29e1c67dbda4f217bc95) | `python3Packages.libarcus: fix build against protobuf 3.18+`                                |
| [`e35d881a`](https://github.com/NixOS/nixpkgs/commit/e35d881ac3cad7d9a52f5bbf6504bacf8aebfcfd) | `auto-cpufreq: 1.6.4 -> 1.6.9`                                                              |
| [`7376977b`](https://github.com/NixOS/nixpkgs/commit/7376977b9e4fd64a60d5017cc1ca603a78cafd22) | `libvmaf: 2.2.0 -> 2.2.1`                                                                   |
| [`aeb13486`](https://github.com/NixOS/nixpkgs/commit/aeb134864cb849d393a5f67941cb36f4f21aa47b) | `libreddit: 0.15.2 -> 0.15.3`                                                               |
| [`4dca3642`](https://github.com/NixOS/nixpkgs/commit/4dca3642cfad9a656ed9a39e35b79e3c8dd86b0c) | `libplctag: 2.3.7 -> 2.4.0`                                                                 |
| [`d929a938`](https://github.com/NixOS/nixpkgs/commit/d929a938f6cc4e7fc3e2f897ed9ce9e1d87e9087) | `jbang: 0.79.0 -> 0.80.1`                                                                   |
| [`a74a864b`](https://github.com/NixOS/nixpkgs/commit/a74a864b0fc5f1194e13c6e84ec9099cdaa5ad2d) | `iotop-c: 1.18 -> 1.19`                                                                     |
| [`9eb591df`](https://github.com/NixOS/nixpkgs/commit/9eb591df1096bc070fa3ac0e2439b6f66e4a7ec5) | `netbsd.compat: fix libs by using cctools strip as objcopy`                                 |
| [`314e0f22`](https://github.com/NixOS/nixpkgs/commit/314e0f22d87ea7e8f3dc63273e59a033f956377b) | `qt512: fixup build of qtwayland`                                                           |
| [`7002c156`](https://github.com/NixOS/nixpkgs/commit/7002c15677dcc285028cff85d30c64da1fcf7879) | `linuxKernel.kernels.linux_5_13_hardened: fix build`                                        |
| [`e095423d`](https://github.com/NixOS/nixpkgs/commit/e095423d1b01e18fc315306619d3e7671a0d5655) | `github-runner: 2.282.1 -> 2.283.1`                                                         |
| [`5102c9bb`](https://github.com/NixOS/nixpkgs/commit/5102c9bb7598cbe3ffe3794e8f231f7e84af9b8a) | `tinycbor: 0.5.3 -> 0.5.4`                                                                  |
| [`d65bef93`](https://github.com/NixOS/nixpkgs/commit/d65bef9357d03b2c07e097eafd2686067c01e30f) | `flyctl: 0.0.240 -> 0.0.241`                                                                |
| [`f89bdb5b`](https://github.com/NixOS/nixpkgs/commit/f89bdb5bc362e33c28b6bb42a06637ad7a5cb31a) | `python3Packages.marshmallow: 3.11.1 -> 3.13.0`                                             |
| [`a98087d7`](https://github.com/NixOS/nixpkgs/commit/a98087d710aa7b874ac0686f7ae02fdb8790169f) | `python3Packages.marshmallow-polyfield: 5.9 -> 5.10`                                        |
| [`8d3c5225`](https://github.com/NixOS/nixpkgs/commit/8d3c52252c21219899b8412cac824cbffda2b267) | `xterm: 368 -> 369`                                                                         |
| [`08b791a0`](https://github.com/NixOS/nixpkgs/commit/08b791a01b35f693d8bb57322da498a7e04a6b62) | `resholve: 0.5.1 -> 0.6.0, refactor, +binlore`                                              |
| [`b1f41c91`](https://github.com/NixOS/nixpkgs/commit/b1f41c918452b0b6a8d7afb14a04063ff56556df) | `ffmpeg: patch CVE-2021-38171 and CVE-2021-38291`                                           |
| [`eb49b17a`](https://github.com/NixOS/nixpkgs/commit/eb49b17a0f4c7df0dad04d761bc9af69a952cbb8) | `upx: disable blanket -Werror (fix gcc-11 build)`                                           |
| [`bbcd0887`](https://github.com/NixOS/nixpkgs/commit/bbcd0887bdf180f3b9fe1d63c48402ea636fbe53) | `gpm: pull upstream fix for -fno-common compiler`                                           |
| [`65be4ada`](https://github.com/NixOS/nixpkgs/commit/65be4ada23bfb63b75df0293c31f5c79f1b84ac7) | `gomuks: 0.2.3 -> 0.2.4`                                                                    |
| [`9e81d39c`](https://github.com/NixOS/nixpkgs/commit/9e81d39c838370bf685d7a53f5aa399a02fd0928) | `fly: 7.4.0 -> 7.5.0`                                                                       |
| [`776745cb`](https://github.com/NixOS/nixpkgs/commit/776745cb4792fe48702c7d50eb92130067fc2a53) | `python38Packages.cvxopt: 1.2.6 -> 1.2.7`                                                   |
| [`f36df15f`](https://github.com/NixOS/nixpkgs/commit/f36df15fe54367c11fa909aabbe14e499f20ec3b) | `mesa: 21.2.1 -> 21.2.2`                                                                    |
| [`3593e19d`](https://github.com/NixOS/nixpkgs/commit/3593e19dc1147569b78325f8a334dfebb6751516) | `home-assistant: disable flaky august component test`                                       |
| [`82ff7320`](https://github.com/NixOS/nixpkgs/commit/82ff73205557d810f3d1453d32705470f120b294) | `nixosTests.pantheon: fix evaluation`                                                       |
| [`dd97523e`](https://github.com/NixOS/nixpkgs/commit/dd97523efec6e1a12989cedef9c572bc29545c6f) | `esphome: 2021.9.0 -> 2021.9.1`                                                             |
| [`879de382`](https://github.com/NixOS/nixpkgs/commit/879de382a6a086a33e2df931e681a84c76032b7d) | `kwin: fix build against libglvnd 1.3.4+`                                                   |
| [`059a86bb`](https://github.com/NixOS/nixpkgs/commit/059a86bbceda8817869c313ecb1b1ce112c067da) | `apycula: init at 0.0.1a9`                                                                  |
| [`d43df749`](https://github.com/NixOS/nixpkgs/commit/d43df749ac4779cdb3f53146c8c1ef66b4f33e33) | `netbsd.compat: fix build on darwin`                                                        |
| [`b23afbb8`](https://github.com/NixOS/nixpkgs/commit/b23afbb86657833f7027f6aed9aae5ea219346ae) | `Revert "csdp: move gfortran to nativeBuildInputs"`                                         |
| [`7f59b4b5`](https://github.com/NixOS/nixpkgs/commit/7f59b4b5295b58659064a91d0bcc8e8a11d0b351) | `sourceHighlight: fix build on darwin`                                                      |
| [`e187f77c`](https://github.com/NixOS/nixpkgs/commit/e187f77cebfb7ef016e6ee1c34b132b4c082a94e) | `hedgedoc: fix eval with `allowAliases = false``                                            |
| [`0a10c17c`](https://github.com/NixOS/nixpkgs/commit/0a10c17c8d01e5f9fefa3d6dbb7802a3cbce7e23) | `hedgedoc: 1.8.2 -> 1.9.0, fixes CVE-2021-39175`                                            |
| [`47961c73`](https://github.com/NixOS/nixpkgs/commit/47961c73be2ac1fa0fee58aec337e384341d962b) | `docs: fix release notes format`                                                            |
| [`8cff7796`](https://github.com/NixOS/nixpkgs/commit/8cff7796d796c2c1e687657346db4abe5677cd09) | `stdenv: re-add isMachO helper function (#138334)`                                          |
| [`ab1ec682`](https://github.com/NixOS/nixpkgs/commit/ab1ec682ac4e8af4617e191e5ac75d3ba5015620) | `opencv3: fix build`                                                                        |
| [`0cf0fac8`](https://github.com/NixOS/nixpkgs/commit/0cf0fac8a0ac2243e6bba846bfe1779c5d31fc71) | `Revert "Merge pull request #137479 from r-ryantm/auto-update/libsigcxx"`                   |