### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0220562772b787d58c48df3434f36da1f552bdc",
-        "sha256": "1nhh4afidrq7crb82ax3f5gqn17scxi7rl6zlxnzcplnwr0waczq",
+        "rev": "2491eb3bdcaf23a2af625d8698470f2a0eac6e72",
+        "sha256": "1fnilshf0qy714pkk6637bn2lfk0mznvvp0gl381jhdgv1kl7h7g",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/d0220562772b787d58c48df3434f36da1f552bdc.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/2491eb3bdcaf23a2af625d8698470f2a0eac6e72.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                        |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`e456e9b1`](https://github.com/NixOS/nixpkgs/commit/e456e9b1ae467c8f83b923dbd2fea337dfe9ff3c) | `sigtool: 0.1.0 -> 0.1.2`                                             |
| [`28d8ad0b`](https://github.com/NixOS/nixpkgs/commit/28d8ad0be1a42ac439f4bfe84df1c1eac4c83506) | `firefox-bin: Don't reference gnome in expression`                    |
| [`8eeb28ff`](https://github.com/NixOS/nixpkgs/commit/8eeb28ffc3cb5265d080626faa76c6e600c32d33) | `firefox-devedition-bin: 90.0b6 -> 93.0b9`                            |
| [`5a566e3e`](https://github.com/NixOS/nixpkgs/commit/5a566e3e7762bdc5ca5f6296f3d72e61dbd597ba) | `firefox-beta-bin: 90.0b6 -> 93.0b9`                                  |
| [`aec24826`](https://github.com/NixOS/nixpkgs/commit/aec248263991541bebfb781376543d26d6c79d7f) | `supertag: fix build caused by outdated lexical-core`                 |
| [`b7d6c648`](https://github.com/NixOS/nixpkgs/commit/b7d6c64871a68f76979015b7434233d84370686e) | `gotestsum: fix package name in ldflags`                              |
| [`eba807d5`](https://github.com/NixOS/nixpkgs/commit/eba807d5949801334cf4742423e8a7d5eb161d26) | `chromiumDev: 95.0.4638.17 -> 96.0.4651.0`                            |
| [`6c3324e2`](https://github.com/NixOS/nixpkgs/commit/6c3324e245a25d9f3417e2f5e7c9c01aadbf7127) | `coqPackages.flocq: 3.3.1 → 3.4.2`                                    |
| [`d9ef3f10`](https://github.com/NixOS/nixpkgs/commit/d9ef3f10e9dcf4ad1cdd55c186c9ae25773446e4) | `watson: Install fish completions.`                                   |
| [`1490399b`](https://github.com/NixOS/nixpkgs/commit/1490399beb4199a79a4a4b83a5bee974f1860f15) | `kanit-font: mirroring latest styling suggestions from chonburi-font` |
| [`59740c03`](https://github.com/NixOS/nixpkgs/commit/59740c03de7f6e3820f6f91e88175df2058b0689) | `chonburi-font: init at unstable-2021-09-15`                          |
| [`37ec684a`](https://github.com/NixOS/nixpkgs/commit/37ec684a5c010aa7cf51abaf29691ef2333d6625) | `psi-notify: init at 1.2.1`                                           |
| [`868a8a52`](https://github.com/NixOS/nixpkgs/commit/868a8a5218542d352ef3abd743df92b291648544) | `python3Packages.aioapns: init 2.0.2`                                 |
| [`5321c273`](https://github.com/NixOS/nixpkgs/commit/5321c273076a272e486e5b138d39ff5a1bec8d8c) | `zeek: 4.1.0 -> 4.1.1`                                                |
| [`afaf8d09`](https://github.com/NixOS/nixpkgs/commit/afaf8d094b98f8099cf29d789d33b122af6ad1ca) | `ungoogled-chromium: 93.0.4577.82 -> 94.0.4606.54`                    |
| [`c1d26607`](https://github.com/NixOS/nixpkgs/commit/c1d266076501052f2241c46e8e69d7169a02d888) | `Update pkgs/tools/audio/kaldi/default.nix`                           |
| [`e1ce3b2e`](https://github.com/NixOS/nixpkgs/commit/e1ce3b2eecef512c4ea2311774fecae0ae63afc8) | `kaldi: fix build`                                                    |
| [`28260c12`](https://github.com/NixOS/nixpkgs/commit/28260c122d83205838429ce1f44e6992d98463cc) | `gokart: 0.2.0 -> 0.3.0`                                              |
| [`fda09976`](https://github.com/NixOS/nixpkgs/commit/fda09976e7c89353ccc47e4b064cd6569c8139da) | `tlsh: 4.9.3 -> 4.10.0`                                               |
| [`82f88110`](https://github.com/NixOS/nixpkgs/commit/82f88110a7341bc4f1a947504a808337c8a7c76c) | `pure-prompt: 1.17.2 -> 1.17.3`                                       |
| [`c6b86076`](https://github.com/NixOS/nixpkgs/commit/c6b86076434a2434a5487151a671eadbbd99c65f) | `vcstool: 0.2.15 -> 0.3.0`                                            |
| [`b01290e0`](https://github.com/NixOS/nixpkgs/commit/b01290e0ecef1b2a57760fdd0facf0f0f48610ae) | `playerctl: 2.3.1 -> 2.4.1`                                           |
| [`a946fb97`](https://github.com/NixOS/nixpkgs/commit/a946fb970f985e20d038e9d12c0db68a8b3b2f19) | `vscode: 1.60.1 -> 1.60.2`                                            |
| [`7cb10233`](https://github.com/NixOS/nixpkgs/commit/7cb102337c1a0c1f453eaba7f07e3823e4595393) | `frugal: 3.14.8 -> 3.14.9`                                            |
| [`365189bf`](https://github.com/NixOS/nixpkgs/commit/365189bf04cb7df06c66d07c14b3134acf1c3564) | `vouch-proxy: 0.34.0 -> 0.34.1`                                       |
| [`512b0ffc`](https://github.com/NixOS/nixpkgs/commit/512b0ffc64e9496a508e5b5fa308e966e2efa95d) | `cutensor_cudatoolkit_11: maintain same version as cudatoolkit_11`    |
| [`0981d947`](https://github.com/NixOS/nixpkgs/commit/0981d9473f646678a7279df30530c5ba51519ebe) | `cudatoolkit_11_{3,4}: init at 11.{3,4}.1`                            |
| [`33a62202`](https://github.com/NixOS/nixpkgs/commit/33a6220244cf59a26d2cfb05f8ad7fcb5c005c3b) | `osl: fix build by overriding llvm-as path`                           |
| [`d8094906`](https://github.com/NixOS/nixpkgs/commit/d80949067f6f724e8513aae939c308ad5b571b86) | `paperless-ng: fix redis connection`                                  |
| [`fdad7052`](https://github.com/NixOS/nixpkgs/commit/fdad7052146efeb0e99bcd14419771177af18ffd) | `abuild: init at 3.7.0`                                               |
| [`06415fe9`](https://github.com/NixOS/nixpkgs/commit/06415fe9b03fd6a9adb36bffc8cf0fb62c313692) | `stripe-cli: 1.5.12 -> 1.7.0`                                         |
| [`4848008b`](https://github.com/NixOS/nixpkgs/commit/4848008b34f302981e89a97ca680877aa245cc57) | `cypress: 8.3.0 -> 8.3.1`                                             |
| [`889e6328`](https://github.com/NixOS/nixpkgs/commit/889e6328f59e7d124e0f0e4882d101bc19607635) | `mandelbulber: 2.24 -> 2.26`                                          |