### PR TITLE
chore(deps): update poetry2nix

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "73f55242232e0ad4f6ece5a5753654354b4627cd",
-        "sha256": "1hviivrri51wwj64j8zrcfb1l7y4zv7pfqapka9rl2k2726hqgks",
+        "rev": "aee8f04296c39d88155e05d25cfc59dfdd41cc77",
+        "sha256": "11r27qy4pnqsqhbvxd3vn6sm1s8zl190d2q1v9k2w0r296bdrw4c",
         "type": "tarball",
-        "url": "https://github.com/nix-community/poetry2nix/archive/73f55242232e0ad4f6ece5a5753654354b4627cd.tar.gz",
+        "url": "https://github.com/nix-community/poetry2nix/archive/aee8f04296c39d88155e05d25cfc59dfdd41cc77.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "pre-commit-hooks": {


### PR DESCRIPTION
| SHA256                                                                                                    | Commit Message                                  |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`aee8f042`](https://github.com/nix-community/poetry2nix/commit/aee8f04296c39d88155e05d25cfc59dfdd41cc77) | `Bump version to 1.21.0`                        |
| [`8cba73cb`](https://github.com/nix-community/poetry2nix/commit/8cba73cb6813d497cf064cb073b1f733cb4190bd) | `Explicitly pass pos to stdenv.mkDerivation`    |
| [`cd659414`](https://github.com/nix-community/poetry2nix/commit/cd659414cacdd885bf378a9299727e6f36a3f485) | `README: recommend overriding env over mkShell` |