### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "96606addcedb821d311c701788062b8864346838",
-        "sha256": "1pja0yrwcj13nbbqakyfsfb90szi0m9lfz4wygm9c7s8gagqxd29",
+        "rev": "6d898617a22b02d5f1ac5c46a703f6ecc3c39cea",
+        "sha256": "0br9ard0swh6nwwm4h12m5glm9wp3rvw2vs7dqdj3qsr6ivddl86",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/96606addcedb821d311c701788062b8864346838.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d898617a22b02d5f1ac5c46a703f6ecc3c39cea.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`d9d63e1f`](https://github.com/NixOS/nixpkgs/commit/d9d63e1f16479b23030277fd835e78cb6a275e82) | `vimPlugins.cmp-tabnine: init at 2021-09-30`                              |
| [`3a1cbf0d`](https://github.com/NixOS/nixpkgs/commit/3a1cbf0df4875fa063f57433340928656a2363f2) | `vimPlugins: update`                                                      |
| [`33b7bd26`](https://github.com/NixOS/nixpkgs/commit/33b7bd2675b8f336224f737fb84e03316ae32e01) | `nixos/gdm: switch to rfc42 style settings`                               |
| [`c41fcde2`](https://github.com/NixOS/nixpkgs/commit/c41fcde24d96c1c0547c9b717dae4f6054176035) | `python3Packages.aioesphomeapi: 9.1.1 -> 9.1.2`                           |
| [`309b14df`](https://github.com/NixOS/nixpkgs/commit/309b14dfcd579b8fc0c8a796871a11648b6e1a7d) | `haskellPackages.quic: provide correct version of network`                |
| [`9485e605`](https://github.com/NixOS/nixpkgs/commit/9485e6053e061e8ae4b29f5bc09021c3538e2650) | `haskellPackages: mark builds failing on hydra as broken`                 |
| [`937f349b`](https://github.com/NixOS/nixpkgs/commit/937f349b5f6ed47591fc373017175efb9cf4d13e) | `rxvt-unicode: fix terminfo path`                                         |
| [`c29f8005`](https://github.com/NixOS/nixpkgs/commit/c29f8005d0d097e1981e6ea84570382ac88a938e) | `gerrit: 3.4.0 -> 3.4.1`                                                  |
| [`e8e1ba49`](https://github.com/NixOS/nixpkgs/commit/e8e1ba49b20c2cb00f5895e6771e2444c5f10bc9) | `python38Packages.sqlmap: 1.5.9 -> 1.5.10`                                |
| [`3e29ee6b`](https://github.com/NixOS/nixpkgs/commit/3e29ee6b71ad9522ec37e14d1ab777f0cba7eecb) | `trunk: 0.13.1 -> 0.14.0`                                                 |
| [`93f38e0a`](https://github.com/NixOS/nixpkgs/commit/93f38e0a7b45bd04683b9d51c4bd0f2a6c65ee5e) | `haskell.packages.ghc921: use network_3_1_2_2`                            |
| [`15b78276`](https://github.com/NixOS/nixpkgs/commit/15b78276daed361e65c307b39daeb4f3ff1870c8) | `haskell.packages.ghc921: re-enable tests previously blocked by 'random'` |
| [`dcff69a8`](https://github.com/NixOS/nixpkgs/commit/dcff69a84019eb4a98d6a7eebd8bb921d97e5ddd) | `haskell.packages.ghc921.ChasingBottoms: remove markBrokenVersion`        |
| [`3533a384`](https://github.com/NixOS/nixpkgs/commit/3533a38478ede359cf230b32f3badfb24eaf1e63) | `haskell.packages.ghc921: use random_1_2_1`                               |
| [`35813c6f`](https://github.com/NixOS/nixpkgs/commit/35813c6f04d74f6ad3f3cbe64976aa549ab17478) | `haskellPackages.candid: 0.2 -> 0.3`                                      |
| [`675e262f`](https://github.com/NixOS/nixpkgs/commit/675e262f5a03eb9aa6b0500434ee30a9d6b882a0) | `nixos/nextcloud: temp fix for MariaDB >=10.6`                            |
| [`c32ea917`](https://github.com/NixOS/nixpkgs/commit/c32ea917d0df019f2e28aab1f3ca074f8698c5af) | `haskellPackages.candid: add workaround for doctest failure`              |
| [`b30b2863`](https://github.com/NixOS/nixpkgs/commit/b30b286371cf649631f99c8ccc0ba4d462673743) | `Add myself as maintainer for a few Haskell packages`                     |
| [`8a19707f`](https://github.com/NixOS/nixpkgs/commit/8a19707fc4ca624b08a8b00b25c0202d31a2a2f5) | `natls: init at 2.1.14`                                                   |
| [`e890cef8`](https://github.com/NixOS/nixpkgs/commit/e890cef8571b899191098395ce5d73e573fb3e86) | `diffoscope: 185 -> 186`                                                  |
| [`f0d1af9b`](https://github.com/NixOS/nixpkgs/commit/f0d1af9bd48aa5071725dc75a76aaa1a0c716fa1) | `tp-auto-kbbl: init at 0.1.5`                                             |
| [`6b9eefb8`](https://github.com/NixOS/nixpkgs/commit/6b9eefb85f59c6d0d91b26180c9e1a2b42cb9f7f) | `php80: 8.0.10 -> 8.0.11`                                                 |
| [`13d37ebb`](https://github.com/NixOS/nixpkgs/commit/13d37ebb64a5e314aad5895c98da886b64886d25) | `php74: 7.4.23 -> 7.4.24`                                                 |
| [`920474b7`](https://github.com/NixOS/nixpkgs/commit/920474b7f7751c4f79a67cafd938d1a2df798d4f) | `gotify: 2.0.21 -> 2.1.0`                                                 |
| [`82155ff5`](https://github.com/NixOS/nixpkgs/commit/82155ff501c7622cb2336646bb62f7624261f6d7) | `rime-array: 2016-09-01 -> 2021-08-24 (#140008)`                          |
| [`72a893c9`](https://github.com/NixOS/nixpkgs/commit/72a893c9d07fbed8ecade2a9998588aac2645268) | `mold: 0.9.3 -> 0.9.6 (#139920)`                                          |
| [`b2bdfd67`](https://github.com/NixOS/nixpkgs/commit/b2bdfd67eb912bee77e1af9214a1a8e635af8191) | `kea: 1.9.11 -> 2.0.0`                                                    |
| [`67ac0371`](https://github.com/NixOS/nixpkgs/commit/67ac0371bca98cbb3b30e65e6c2b4ca1887ad442) | `vimPlugins.nvim-cursorline: init at 2021-09-28`                          |
| [`60385180`](https://github.com/NixOS/nixpkgs/commit/6038518014b4933c0baac44e0dee94592a8137db) | `vimPlugins.TrueZen-nvim: init at 2021-09-11`                             |
| [`52428b73`](https://github.com/NixOS/nixpkgs/commit/52428b73f65f9454717cc4718ad41252a883df42) | `vimPlugins: update`                                                      |
| [`378d2c5d`](https://github.com/NixOS/nixpkgs/commit/378d2c5dcec7fef958cca3760448c09a9be2b7a3) | `erofs-utils: 1.2.1 -> 1.3`                                               |
| [`4a719dfa`](https://github.com/NixOS/nixpkgs/commit/4a719dfa45192030f38dccf099c17cbe8279d9ca) | `unrar: 5.9.2 -> 6.0.7`                                                   |
| [`4b5042ca`](https://github.com/NixOS/nixpkgs/commit/4b5042caf31af1e6eb750658a9bf547471228d75) | `coqPackages.paramcoq: 1.1.2 → 1.1.3`                                     |
| [`decdbc35`](https://github.com/NixOS/nixpkgs/commit/decdbc35693d4edbb6b084c4e344ca3db182365a) | `qemu: enable hvf acceleration on aarch64-darwin (#139960)`               |
| [`642ca739`](https://github.com/NixOS/nixpkgs/commit/642ca73937decde097a6c83205f48a5ac081fe94) | `linux/hardened/patches/5.4: 5.4.149-hardened1 -> 5.4.150-hardened1`      |
| [`dd93aec4`](https://github.com/NixOS/nixpkgs/commit/dd93aec4c4905c17f17020658ed1f5858c9d6b81) | `linux/hardened/patches/5.14: 5.14.8-hardened1 -> 5.14.9-hardened1`       |
| [`f178ff4a`](https://github.com/NixOS/nixpkgs/commit/f178ff4a04c8d4e2ed43e6538a1aac336bfa891c) | `linux/hardened/patches/5.10: 5.10.69-hardened1 -> 5.10.70-hardened1`     |
| [`6937daff`](https://github.com/NixOS/nixpkgs/commit/6937daff0d376cfe33ec7945f768a66beaee0eaf) | `linux: 5.4.149 -> 5.4.150`                                               |
| [`b540e8b5`](https://github.com/NixOS/nixpkgs/commit/b540e8b5a9082f8150fb3de37e793bc5cef25388) | `linux: 5.14.8 -> 5.14.9`                                                 |
| [`8417ed79`](https://github.com/NixOS/nixpkgs/commit/8417ed79d87f44c35af2e698921988c6525eedb1) | `linux: 5.10.69 -> 5.10.70`                                               |
| [`ea41520b`](https://github.com/NixOS/nixpkgs/commit/ea41520b71bfc07668a535feae1abe093e0139e5) | `gitRepo: 2.16.8 -> 2.17`                                                 |
| [`20233d45`](https://github.com/NixOS/nixpkgs/commit/20233d45c4ec992e5094e858b25e6531d80466e0) | `clojure-lsp: 2021.09.13-22.25.35 -> 2021.09.30-15.28.01`                 |
| [`a9454f53`](https://github.com/NixOS/nixpkgs/commit/a9454f539b02b99d4192ff9964050368bda5e13f) | `resholve: actually import resholveScript*`                               |
| [`5e2c33f1`](https://github.com/NixOS/nixpkgs/commit/5e2c33f1049432cb76492d0eb12fb74a0ecd8875) | `emu2: unstable-2020-06-04 -> 0.0.0+unstable=2021-09-22`                  |
| [`651f0046`](https://github.com/NixOS/nixpkgs/commit/651f00467f35e2d64f061e910bef5ea439359a82) | `soapysdr: enable on darwin`                                              |
| [`6ff40871`](https://github.com/NixOS/nixpkgs/commit/6ff40871c0a5873ef510ff10a1edbef327bc6ae6) | `wget2: 1.99.2 -> 2.0.0`                                                  |
| [`49573709`](https://github.com/NixOS/nixpkgs/commit/49573709c5f842f0e3fbe4da3cd02f1c74aa9b1b) | `nextcloud: 20.0.12 -> 20.0.13, 21.0.4 -> 21.0.5, 22.1.1 -> 22.2.0`       |
| [`d55ffa5a`](https://github.com/NixOS/nixpkgs/commit/d55ffa5a2fd1fb9f0ed4ec93bd27f0990a2cb2f9) | `haskellPackages.nvfetcher: disable check`                                |
| [`a807cd3a`](https://github.com/NixOS/nixpkgs/commit/a807cd3a00e49dfbb37572faa84158fbe2ebac51) | `nixos/extra-container: init`                                             |
| [`e02190a5`](https://github.com/NixOS/nixpkgs/commit/e02190a5d08e90f0a51ab7d8dce228ae34942a0a) | `extra-container: init at 0.8`                                            |
| [`5cc05024`](https://github.com/NixOS/nixpkgs/commit/5cc050244d338a8ccbfc152f6146b98da6069700) | `dasel: 1.20.0 -> 1.21.1`                                                 |
| [`48eba3e3`](https://github.com/NixOS/nixpkgs/commit/48eba3e35c10d11b709af420f96a346022a6fc55) | `ocamlPackages.lustre-v6: init at 6.103.3`                                |
| [`f1132b0f`](https://github.com/NixOS/nixpkgs/commit/f1132b0ff1e3b7f4fc3a8dfece06607854c7fbaa) | `ocaml-lsp: 1.7.0 -> 1.8.3`                                               |
| [`073cc84c`](https://github.com/NixOS/nixpkgs/commit/073cc84c9b87157d2df46dbc3deaaddb6fe77e42) | `ocamlformat-rpc-lib: init at 0.19.0`                                     |
| [`52b10ee8`](https://github.com/NixOS/nixpkgs/commit/52b10ee8725e3fde6bb5fc297b997d7c1bc59930) | `vmTools refactor: don't use huge `with pkgs;``                           |
| [`e3066b5e`](https://github.com/NixOS/nixpkgs/commit/e3066b5e9f649082456211782075b5044a68d30d) | `vmTools: fixup after adding the `img` package`                           |
| [`52babc1b`](https://github.com/NixOS/nixpkgs/commit/52babc1baa2bf01e6d897e784e3f8706d4fac8fb) | `glab: 1.20.0 -> 1.21.1`                                                  |
| [`4725dfec`](https://github.com/NixOS/nixpkgs/commit/4725dfecf6e987d32d5035e93abb2299653bb72d) | `google-java-format: fix for jdk 16`                                      |
| [`ad7eb5b4`](https://github.com/NixOS/nixpkgs/commit/ad7eb5b4e60f2343142c52e272b112faa0feaa5e) | `higan: 110 -> 115+unstable=2021-08-18`                                   |
| [`f848a875`](https://github.com/NixOS/nixpkgs/commit/f848a875360ccf9bd72467879b8370119c88d5dd) | `tailscale: add support for Darwin`                                       |
| [`53527927`](https://github.com/NixOS/nixpkgs/commit/53527927eb4c0cee87388f9460fbb0c25755ce35) | `cbqn: init at 0.0.0+unstable=2021-09-29`                                 |
| [`589e03f1`](https://github.com/NixOS/nixpkgs/commit/589e03f109092a3ba97781fd0533110bf78a3f97) | `diffoscope: 183 -> 185`                                                  |
| [`209b1e43`](https://github.com/NixOS/nixpkgs/commit/209b1e43471a853883ca3c862006894585baeb01) | `gocryptfs: ensure fusermount setuid wrapper is used if present`          |
| [`008e1264`](https://github.com/NixOS/nixpkgs/commit/008e12644853b85e8e0741e5815aa4fcf3df3423) | `mopidy-ytmusic: init at 0.3.2`                                           |
| [`c4112ea9`](https://github.com/NixOS/nixpkgs/commit/c4112ea936a3b681f3983079de84586b571c59b4) | `mopidy-mpd: 3.0.0 -> 3.2.0`                                              |
| [`c642999a`](https://github.com/NixOS/nixpkgs/commit/c642999add458f1761e66aafeb19d8c504ab89c5) | `expolitdb: 2021-09-29 -> 2021-09-30`                                     |
| [`62d2fc1c`](https://github.com/NixOS/nixpkgs/commit/62d2fc1ccae90859243351474a9e9e0614bc017d) | `leiningen: 2.9.6 -> 2.9.7`                                               |
| [`e1f3bc62`](https://github.com/NixOS/nixpkgs/commit/e1f3bc6204d9317f21237fd765deac2d70a1f410) | `mopidy-mpris: 3.0.2 -> 3.0.3`                                            |
| [`e3b85ac8`](https://github.com/NixOS/nixpkgs/commit/e3b85ac8bc72b12670804962305ec4b3985bf29e) | `clj-kondo: 2021.03.31 -> 2021.09.25`                                     |
| [`ffea2549`](https://github.com/NixOS/nixpkgs/commit/ffea254935c36683607aeb95f281a5eb0158313f) | `heisenbridge: 1.2.0 -> 1.2.1`                                            |
| [`c0a8ff18`](https://github.com/NixOS/nixpkgs/commit/c0a8ff18be21f289cf65dc3da15e99df698425bd) | `python38Packages.lazy_import: quote homepage (#140031)`                  |
| [`6431f731`](https://github.com/NixOS/nixpkgs/commit/6431f7316fed74810bbc13c69ed718d7f7075064) | `python38Packages.tensorboard-plugin-wit: quote homepage (#140034)`       |
| [`becb0478`](https://github.com/NixOS/nixpkgs/commit/becb04784c1e06f96e70a0135deb2e0dd79c4d70) | `python3Packages.millheater: 0.5.2 -> 0.6.0`                              |
| [`1d696ae8`](https://github.com/NixOS/nixpkgs/commit/1d696ae86febb3b074987c67f318167d1ce2782e) | `python38Packages.packet-python: 1.44.0 -> 1.44.1`                        |
| [`c3e39c51`](https://github.com/NixOS/nixpkgs/commit/c3e39c51a71ea2df84091ebef954cf5cd7057121) | `nextcloud-client: 3.3.4 -> 3.3.5`                                        |
| [`3a07e14f`](https://github.com/NixOS/nixpkgs/commit/3a07e14fe9c6077209cd4f12bacb23d601985677) | `nvme-cli: 1.14 -> 1.15`                                                  |
| [`41f22bd5`](https://github.com/NixOS/nixpkgs/commit/41f22bd5c727b670819b0b1933a284425b182c25) | `python38Packages.mypy-boto3-s3: 1.18.50 -> 1.18.51`                      |
| [`963773ea`](https://github.com/NixOS/nixpkgs/commit/963773eafa5e390ecd01069de0ab40d79f2eb4f7) | `zellij: 0.18.0 -> 0.18.1`                                                |
| [`6fd63365`](https://github.com/NixOS/nixpkgs/commit/6fd63365fc48f27e3cf355f5d5c097a8af77d34f) | `koka: 2.1.9 -> 2.3.1`                                                    |
| [`8346dc04`](https://github.com/NixOS/nixpkgs/commit/8346dc04b31bc4ade35bd15a72e6cc40c8ac2f73) | `pict-rs: add initial module`                                             |
| [`1320843a`](https://github.com/NixOS/nixpkgs/commit/1320843aade014d9c199296c6dc0528de11451cd) | `pict-rs: fixes`                                                          |
| [`2e13a9cc`](https://github.com/NixOS/nixpkgs/commit/2e13a9cc6d8420e7d778127b36ff0ad6a8158f33) | `electrs: fix missing metrics feature`                                    |
| [`37d2d14c`](https://github.com/NixOS/nixpkgs/commit/37d2d14c04c2b6aadb63ca9a19f0c5e9bde7c057) | `friture: fix desktop item`                                               |
| [`802321a4`](https://github.com/NixOS/nixpkgs/commit/802321a44282f7bf716fce0e4a14ac46d607456e) | `signal-desktop: 5.17.2 -> 5.18.0`                                        |
| [`f94419a3`](https://github.com/NixOS/nixpkgs/commit/f94419a3a87be8adad25bb81662aefa9384a8226) | `libva-utils: 2.12.0 -> 2.13.0`                                           |
| [`b5da25f1`](https://github.com/NixOS/nixpkgs/commit/b5da25f1c9edbbcc01b9dd19e95d6eb149498463) | `dnstake: init at 0.0.2 (#139869)`                                        |
| [`97dc734a`](https://github.com/NixOS/nixpkgs/commit/97dc734ab591b8b26e0d2f9c54dd5d6eac022a00) | `python38Packages.imbalanced-learn: 0.8.0 -> 0.8.1`                       |
| [`81328a0f`](https://github.com/NixOS/nixpkgs/commit/81328a0f6a3fe95fbdb500e551e14d3c4a8f0a70) | `python3Packages.total-connect-client: 2021.7.1 -> 2021.8.3`              |
| [`22aad265`](https://github.com/NixOS/nixpkgs/commit/22aad26526a06d85079d4488ade82dea451e07ce) | `source-han-*: use fetchzip instead of mkDerivation`                      |
| [`2e262587`](https://github.com/NixOS/nixpkgs/commit/2e262587ae0810ebb4f1e65d1d73efb72a5d74a5) | `python38Packages.google-cloud-spanner: 3.10.0 -> 3.11.0`                 |
| [`0ec6fc72`](https://github.com/NixOS/nixpkgs/commit/0ec6fc72a0cc81a53684b3a816c89e6511250a58) | `hledger-check-fancyassertions: init at 1.23`                             |
| [`a41e19ca`](https://github.com/NixOS/nixpkgs/commit/a41e19ca718eeabc2e9205e72608f50a933e9648) | `chromiumBeta: 95.0.4638.17 -> 95.0.4638.32`                              |
| [`f6703cdd`](https://github.com/NixOS/nixpkgs/commit/f6703cdddc551769a1b8c41e8a300400facdb3a2) | `haskellPackages.hledger-lib_1_23: build with doctest 0.18.1`             |
| [`6703f159`](https://github.com/NixOS/nixpkgs/commit/6703f159a79e066f751c66968becbe68f2c6bfc0) | `ko: 0.8.3 -> 0.9.3`                                                      |
| [`9a6d6c36`](https://github.com/NixOS/nixpkgs/commit/9a6d6c36e7888cb98f50ad84658a352884922ea9) | `haskellPackages.hls-call-hierarchy-plugin: dontCheck on darwin`          |
| [`c2b15153`](https://github.com/NixOS/nixpkgs/commit/c2b15153a8f982fda721034cb9e62e0b01768008) | `electrs: 0.8.12 -> 0.9.0`                                                |
| [`4236dfe2`](https://github.com/NixOS/nixpkgs/commit/4236dfe203c24c1cee4b6705fed9c36e90115e8b) | `jre_minimal: document how to use a headless JDK`                         |
| [`1e97c325`](https://github.com/NixOS/nixpkgs/commit/1e97c325b3f3a28cb6e156941f4876385f6fd19e) | `pcloud: 1.9.5 -> 1.9.7`                                                  |
| [`c1e2fc60`](https://github.com/NixOS/nixpkgs/commit/c1e2fc6045f576b29d4950d61ca26e8dc6a4411b) | `gdown: 3.13.1 -> 3.14.0`                                                 |
| [`27983d14`](https://github.com/NixOS/nixpkgs/commit/27983d14543382a70293fd4bbc449cdc52e0d0df) | `python3Packages.pynobo: 1.2.0 -> 1.3.0`                                  |
| [`155362f3`](https://github.com/NixOS/nixpkgs/commit/155362f36cd92cff3ccf91ffd4322d51d4bb568e) | `python3Packages.somecomfort: 0.5.2 -> 0.6.0`                             |
| [`443fba35`](https://github.com/NixOS/nixpkgs/commit/443fba3566be4480d1ad463d4acf482270257173) | `python38Packages.cx_Freeze: 6.7 -> 6.8.1`                                |
| [`e6276d6d`](https://github.com/NixOS/nixpkgs/commit/e6276d6da39a636f74b78db54480b40d8e8165ce) | `python38Packages.cupy: 9.4.0 -> 9.5.0`                                   |
| [`d62a5652`](https://github.com/NixOS/nixpkgs/commit/d62a56529049d0cece44261f09fff1dc7b7a6042) | `haruna: 0.6.3 -> 0.7.2`                                                  |
| [`1aa48d7f`](https://github.com/NixOS/nixpkgs/commit/1aa48d7fd6bd874d90b7e8da1680fa9d92a5d9cf) | `sc68: unstable-2020-05-18 -> unstable-2021-08-23`                        |
| [`36e96619`](https://github.com/NixOS/nixpkgs/commit/36e96619438ba8a08f6080dbb53ab34aa1bb63f1) | `home-assistant: enable mythicbeastsdns tests`                            |
| [`1dd8f94d`](https://github.com/NixOS/nixpkgs/commit/1dd8f94d72c3b66bce210fd205b471dda2dca814) | `python3Packages.mypy-boto3-builder: 5.4.0 -> 5.5.0`                      |
| [`265006a4`](https://github.com/NixOS/nixpkgs/commit/265006a49312a5f2251a961c64f843aaa2306f9c) | `python38Packages.holidays: 0.11.3 -> 0.11.3.1`                           |
| [`824043e0`](https://github.com/NixOS/nixpkgs/commit/824043e09c9421d6750f60abca9b23d7699868ea) | `ocamlPackages.uucd: 13.0.0 → 14.0.0`                                     |
| [`93d737f7`](https://github.com/NixOS/nixpkgs/commit/93d737f732c15fe0afa94196f2e92645eaaa223d) | `python38Packages.ephem: 4.0.0.2 -> 4.1`                                  |
| [`76b1e16c`](https://github.com/NixOS/nixpkgs/commit/76b1e16c6659ccef7187ca69b287525fea133244) | `postgresql_14: beta3 -> 14.0`                                            |
| [`094ce659`](https://github.com/NixOS/nixpkgs/commit/094ce6598bd5832a3c3a45bd0edd20a8ff274672) | `lab: 0.22.0 -> 0.23.0`                                                   |
| [`d8a7d226`](https://github.com/NixOS/nixpkgs/commit/d8a7d2262c79e953a936ef810fd487a829655b7f) | `postgresqlPackages.pg_cron: 1.3.1 -> 1.4.1`                              |
| [`95356604`](https://github.com/NixOS/nixpkgs/commit/953566041065b510dfa83bfab5899a88ee07da79) | `bochs: Enable nogui display backend`                                     |
| [`c779050e`](https://github.com/NixOS/nixpkgs/commit/c779050edb56f5958d28af7aec444c14f6a18163) | `poetry2nix: 1.20.0 -> 1.21.0`                                            |
| [`e5b3f177`](https://github.com/NixOS/nixpkgs/commit/e5b3f1774423af475f7019a22d8c72d180ef6f2d) | `pantheon.gala: 6.2.0 -> 6.2.1`                                           |
| [`c4035d72`](https://github.com/NixOS/nixpkgs/commit/c4035d7234d3b020e230f1094ae1e5efd64d7aa0) | `saleae-logic-2: add desktop item`                                        |
| [`8bcd17d6`](https://github.com/NixOS/nixpkgs/commit/8bcd17d6a859b44b24e5ef5d14e0fc6a2eaf9c69) | `terraform_1_0: 1.0.7 -> 1.0.8`                                           |
| [`1f7f8739`](https://github.com/NixOS/nixpkgs/commit/1f7f87396ca180543b997a3a8806212da8a3fd67) | `chromiumDev: 96.0.4651.0 -> 96.0.4655.0`                                 |
| [`8b1e1396`](https://github.com/NixOS/nixpkgs/commit/8b1e1396225790a0a1fb7961a4848c773737cff9) | `photoflow: mark as broken`                                               |