### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6d898617a22b02d5f1ac5c46a703f6ecc3c39cea",
-        "sha256": "0br9ard0swh6nwwm4h12m5glm9wp3rvw2vs7dqdj3qsr6ivddl86",
+        "rev": "6fa4e75f7622ccedee8cb58a8d2ecaa658667a10",
+        "sha256": "1f4i71z30i9rfrvaapahwbhwj8zwl20yh1dgzpmbfh4x4zgxdnsd",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6d898617a22b02d5f1ac5c46a703f6ecc3c39cea.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6fa4e75f7622ccedee8cb58a8d2ecaa658667a10.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`2e4938eb`](https://github.com/NixOS/nixpkgs/commit/2e4938eb6a7d594aa3884e903ac40270c5af2258) | `cfdyndns: fix startAt by setting it to *:0/5 instead of 5 minutes`              |
| [`247bdd7f`](https://github.com/NixOS/nixpkgs/commit/247bdd7f70d94ef4ff51a098c57fa80c919efb9d) | `python3Packages.marisa-trie: add readme_renderer (#140323)`                     |
| [`89032313`](https://github.com/NixOS/nixpkgs/commit/89032313ca28ecc6a30abbc4b64d9dccaf499209) | `redis: set mainProgram to redis-cli`                                            |
| [`3a5f9bd5`](https://github.com/NixOS/nixpkgs/commit/3a5f9bd5e5b43fd46b97cb12c42efe2c8f0d9f3c) | `vivaldi-ffmpeg-codecs: 78.0.3904.70 -> 94.0.4606.50`                            |
| [`d37df0b6`](https://github.com/NixOS/nixpkgs/commit/d37df0b6756ee7633a05f7a3e2fc94a0ba798fef) | `vimPlugins.nightfox-nvim: init at 2021-10-01`                                   |
| [`8ce19c93`](https://github.com/NixOS/nixpkgs/commit/8ce19c9399370cb9c173af1b15bf970004946258) | `electron_12: 12.1.2 -> 12.2.1`                                                  |
| [`925e11b8`](https://github.com/NixOS/nixpkgs/commit/925e11b83225053f54ee834b649ab85789f035a8) | `obspy: init at 1.2.2`                                                           |
| [`e2a89b0e`](https://github.com/NixOS/nixpkgs/commit/e2a89b0e46a724f59dedc7780e9763a9b4f20b6e) | `electron_13: 13.4.0 -> 13.5.1`                                                  |
| [`4702df22`](https://github.com/NixOS/nixpkgs/commit/4702df224b9ddd58d93afa51f888faa227d0aa6a) | `electron_14: 14.0.1 -> 14.1.0`                                                  |
| [`f017f692`](https://github.com/NixOS/nixpkgs/commit/f017f6926e9e4f80b10288e4059476ed01875db5) | `maintainers: add @matilde-ametrine`                                             |
| [`96c0f7e4`](https://github.com/NixOS/nixpkgs/commit/96c0f7e4ddf2104da88ff5a098163b73677d5b2d) | `rustPackages.rls: Fix 1.55 build on Darwin (#140232)`                           |
| [`ad7fdc00`](https://github.com/NixOS/nixpkgs/commit/ad7fdc005eaed6a17dab4dcefe3ac2322a269f43) | `vimPlugins: update`                                                             |
| [`d5a9d969`](https://github.com/NixOS/nixpkgs/commit/d5a9d96982d15ae5770af5975c52266ca2514ef4) | `direwolf: fix build`                                                            |
| [`537d144f`](https://github.com/NixOS/nixpkgs/commit/537d144f64b0da61f3562a7fa756b160179acba8) | `libdecor: fix cross compile`                                                    |
| [`98ca06bd`](https://github.com/NixOS/nixpkgs/commit/98ca06bd04c1b96929712087383f2bef189c960c) | `vimPlugins.markdown-preview-nvim: remove executable check`                      |
| [`175dbdb0`](https://github.com/NixOS/nixpkgs/commit/175dbdb076189b1da5770a2de05e0dd42b1981bf) | `croc: 9.3.0 -> 9.4.2`                                                           |
| [`37668736`](https://github.com/NixOS/nixpkgs/commit/376687365050b4cd7fb72151a527c99d135725bc) | `rpl: remove superfluous let in`                                                 |
| [`a4df6db5`](https://github.com/NixOS/nixpkgs/commit/a4df6db57dd68f7d5dad5dd56aadae57327048d2) | `rpl: update to 4467bd4 (#140161)`                                               |
| [`e18f0df4`](https://github.com/NixOS/nixpkgs/commit/e18f0df44bce45e39c3db7e0916b56e215ee273a) | `sonarr: 3.0.6.1266 -> 3.0.6.1342`                                               |
| [`4766e365`](https://github.com/NixOS/nixpkgs/commit/4766e365d34b7a9925b79f19e5e1bfe691b72294) | `cni-plugin-flannel: 1.0 -> 1.1`                                                 |
| [`dbd9ca8d`](https://github.com/NixOS/nixpkgs/commit/dbd9ca8d1b3a02f29f68c2a3c9058e31ab8ed93f) | `python3Packages.pyturbojpeg: 1.5.4 -> 1.6.1`                                    |
| [`775c2a23`](https://github.com/NixOS/nixpkgs/commit/775c2a236b9be4f023394b9cef408dfe4e82a620) | `python3Packages.pyserial-asyncio: add pythonImportsCheck`                       |
| [`dedd0f63`](https://github.com/NixOS/nixpkgs/commit/dedd0f6308443d85d7117bc78698a4761d868ca9) | `python3Packages.pyserial-asyncio: 0.5 -> 0.6`                                   |
| [`0219679e`](https://github.com/NixOS/nixpkgs/commit/0219679ed0d2325e5c828e1ef16ad4a5c7cfdb2e) | `mpvScripts.mpv-playlistmanager: unstable-2021-08-17 -> unstable-2021-09-27`     |
| [`ac2a0f27`](https://github.com/NixOS/nixpkgs/commit/ac2a0f27573ebf76f3aaa5b16c027f3cf98aa839) | `python3Packages.ocrmypdf: set version manually`                                 |
| [`b4ba2917`](https://github.com/NixOS/nixpkgs/commit/b4ba29173d06674a764a666c358bfa5d3b1e3983) | `python3Packages.nunavut: fix build`                                             |
| [`642eb3f6`](https://github.com/NixOS/nixpkgs/commit/642eb3f64179dfce0789823d14cbee8f390e329e) | `goaccess: 1.5.1 -> 1.5.2`                                                       |
| [`faf57c8e`](https://github.com/NixOS/nixpkgs/commit/faf57c8e3a35eaf155fa2c7dcfeb7a0ed2fb3f57) | `analog: Fix substitution so it can find its language files (#133540)`           |
| [`e417cc71`](https://github.com/NixOS/nixpkgs/commit/e417cc7156a5e00909d7360037f3940d91569515) | `python3Packages.nettigo-air-monitor: 1.0.0 -> 1.1.0`                            |
| [`98088c76`](https://github.com/NixOS/nixpkgs/commit/98088c76a829db271852ef58ff4d4279aa13cebb) | `rustcat: 1.3.0 -> 2.0.0`                                                        |
| [`c7d875af`](https://github.com/NixOS/nixpkgs/commit/c7d875af1cce073d4bac487ae43a9c83663db073) | `gnome.gnome-tweaks: patch python script in libexec`                             |
| [`99fb649f`](https://github.com/NixOS/nixpkgs/commit/99fb649fbc90d07521761a7c31d64554b02853b1) | `stevenblack-blocklist: 3.8.2 -> 3.9.7`                                          |
| [`805cb834`](https://github.com/NixOS/nixpkgs/commit/805cb8341840e06a6a127fc013ac6a1798032717) | `tailscale: 1.14.4 -> 1.14.6`                                                    |
| [`82b6455c`](https://github.com/NixOS/nixpkgs/commit/82b6455cc222d540c8ce7a2995c1b2d165299d69) | `cups-filters: define mutool path and localstatedir,sysconfdir`                  |
| [`e90cfad2`](https://github.com/NixOS/nixpkgs/commit/e90cfad2bed9fd215be46e05316ab2e851a828d4) | `yaru-theme: 21.10.1 -> 21.10.2`                                                 |
| [`b2a2f6c8`](https://github.com/NixOS/nixpkgs/commit/b2a2f6c86d5257a01d5600e28e029534bf087cac) | `castor: 0.8.16 -> 0.8.18`                                                       |
| [`cb2aeac3`](https://github.com/NixOS/nixpkgs/commit/cb2aeac38b7b97d58cb2acef0a246f426360902b) | `elfcat: 0.1.6 -> 0.1.7`                                                         |
| [`0ceef669`](https://github.com/NixOS/nixpkgs/commit/0ceef669f7b2f2b9180c8bee949a198f50f9140d) | `python3Packages.frigidaire: init at 0.16`                                       |
| [`5430af20`](https://github.com/NixOS/nixpkgs/commit/5430af2013535e48facb1f660565db70aebb7e6b) | `dwfv: init at 0.4.1`                                                            |
| [`d672332c`](https://github.com/NixOS/nixpkgs/commit/d672332c26371a50c76f52e379795eb974ff6f65) | `clojure-lsp: remove "-H:CheckToolchain" on macOS`                               |
| [`b2092aae`](https://github.com/NixOS/nixpkgs/commit/b2092aae6f4cc85fe70d2f486e1211f038d50b8c) | `drawpile: 2.1.19 -> 2.1.20`                                                     |
| [`a77c1b39`](https://github.com/NixOS/nixpkgs/commit/a77c1b39b8409833998b3ff65859ccfa3e3bd592) | `step-ca: 0.16.2 -> 0.17.4`                                                      |
| [`db4de0e9`](https://github.com/NixOS/nixpkgs/commit/db4de0e903c781e41c15aeba264d3cdd0c04f9c5) | `papirus-icon-theme: 20210901 -> 20211001`                                       |
| [`07be670c`](https://github.com/NixOS/nixpkgs/commit/07be670cf94fa896832689c3f59f73b49ef1ad13) | `graalvm-ce: create empty lib directory on macOS`                                |
| [`f9d6a888`](https://github.com/NixOS/nixpkgs/commit/f9d6a88874f336ac4ce40e4e220ade3df06cf027) | `gnomeExtensions: Auto-update`                                                   |
| [`e4a1d329`](https://github.com/NixOS/nixpkgs/commit/e4a1d3292219f0d1d140da5eb912fef1dfcbc630) | `zprint: reduce closure size`                                                    |
| [`72971ccc`](https://github.com/NixOS/nixpkgs/commit/72971ccccb8063e018480c0ad60a824472a3b08d) | `clojure-lsp: reduce closure size`                                               |
| [`bc40a84b`](https://github.com/NixOS/nixpkgs/commit/bc40a84b554a85f5bdfd782c487a3536301c2dfd) | `clj-kondo: refactor and reduce closure size`                                    |
| [`e7b37408`](https://github.com/NixOS/nixpkgs/commit/e7b3740842a3f82c9235d0dc48867653d2a73c96) | `babashka: reduce closure size`                                                  |
| [`d909c0c1`](https://github.com/NixOS/nixpkgs/commit/d909c0c1f1ba4e5fad7339c7d7bb4386add3441f) | `graalvm-ce: add lib output`                                                     |
| [`edaa339e`](https://github.com/NixOS/nixpkgs/commit/edaa339eab469c69d0fdeb8396ca31a03ca6843f) | `python3Packages.amberelectric: init at 1.0.3`                                   |
| [`0d9299b6`](https://github.com/NixOS/nixpkgs/commit/0d9299b6a774deae66221cb0141d285a61e972df) | `erlang: 24.0.6 -> 24.1.1`                                                       |
| [`33aad631`](https://github.com/NixOS/nixpkgs/commit/33aad6316efe71bf4e788158d365c21733504c32) | `python3Packages.tuya-iot-py-sdk: init at 0.5.0`                                 |
| [`84b08df9`](https://github.com/NixOS/nixpkgs/commit/84b08df988ec18cb36058e9e700c2b2d0833d23d) | `vscode-extensions.influxdata.flux: init at 0.6.5.`                              |
| [`04269f4b`](https://github.com/NixOS/nixpkgs/commit/04269f4be1dc349532138237a9dd2bd6f884c436) | `python3Packages.hstspreload: 2021.9.1 -> 2021.10.1`                             |
| [`e5fe6f4c`](https://github.com/NixOS/nixpkgs/commit/e5fe6f4c58d229e8f74cd5738912abb83c482b2f) | `skawarePackages.buildManPages: drop unnecessary sections parameter`             |
| [`20207026`](https://github.com/NixOS/nixpkgs/commit/2020702689dbfcb62cd6ddae5cf1dda42e95629c) | `s6-networking-man-pages: 2.4.1.1.1 -> 2.5.0.0.1`                                |
| [`3cf522b2`](https://github.com/NixOS/nixpkgs/commit/3cf522b28641ffd4fa0ccfbdac8d4c0696dd358e) | `s6-man-pages: 2.10.0.3.1 -> 2.11.0.0.1`                                         |
| [`4d631edc`](https://github.com/NixOS/nixpkgs/commit/4d631edcab4b456a074089e88875b3cc975e6ddf) | `execline-man-pages: 2.8.0.1.1 -> 2.8.1.0.1`                                     |
| [`f05c5e07`](https://github.com/NixOS/nixpkgs/commit/f05c5e07e18d1fe9fbc88729c35079e032efeb42) | `hydrus: 454 -> 456`                                                             |
| [`1d5d0bb9`](https://github.com/NixOS/nixpkgs/commit/1d5d0bb97ff8fbf9a1df7d8f3f379360531ce4ce) | `neil: init at 0.0.13`                                                           |
| [`c48c8253`](https://github.com/NixOS/nixpkgs/commit/c48c82533b4701e9e40c30339a0bcf96cef3f239) | `ssh-key-confirmer: init at 0.1`                                                 |
| [`bb07abf4`](https://github.com/NixOS/nixpkgs/commit/bb07abf44d3573aa865a0f7612bbb149810b53e8) | `headscale: 0.8.1 -> 0.9.2`                                                      |
| [`8690708b`](https://github.com/NixOS/nixpkgs/commit/8690708bc2a9ba546564a3e76e01a5e6488e1c9b) | `python38Packages.qcengine: 0.19.0 -> 0.20.0`                                    |
| [`55e05e8e`](https://github.com/NixOS/nixpkgs/commit/55e05e8e0b14679521ab3d0364faab99451f121a) | `intel-media-driver: 21.3.3 -> 21.3.4`                                           |
| [`f841bc7c`](https://github.com/NixOS/nixpkgs/commit/f841bc7c06aa12eea285a579de283b1b44ed3e8d) | `step-cli: 0.17.2 -> 0.17.6`                                                     |
| [`40c61e52`](https://github.com/NixOS/nixpkgs/commit/40c61e528f0c7f503e73666ee60ab064b8a0944b) | `ocamlPackages.logs: make jsoo support optional`                                 |
| [`ac499094`](https://github.com/NixOS/nixpkgs/commit/ac4990944f68bdd44a56ebcc0ede27d4854a8269) | `python3Packages.pynws: 1.3.0 -> 1.3.1`                                          |
| [`8b094bcb`](https://github.com/NixOS/nixpkgs/commit/8b094bcb6c5600d807e7fb6daded5b477252959e) | `python3Packages.identify: 2.2.15 -> 2.3.0`                                      |
| [`f086392b`](https://github.com/NixOS/nixpkgs/commit/f086392b503465e5145640c00b34bab53b464e7c) | `amass: 3.13.4 -> 3.14.0`                                                        |
| [`104fd7c3`](https://github.com/NixOS/nixpkgs/commit/104fd7c3f6e17928ab498c8fe0967bd233042c10) | `python3Packages.django_taggit: add djangorestframework`                         |
| [`731d6768`](https://github.com/NixOS/nixpkgs/commit/731d67683c274672f767adff510e91a493489188) | `blender: darwin app dir fixes`                                                  |
| [`3536f32a`](https://github.com/NixOS/nixpkgs/commit/3536f32a43a47d1d92ee4d23f93c9bb1658593dd) | `emacsPackages.bqn-mode: 0.0.0+unstable=2021-09-26 -> 0.0.0+unstable=2021-09-27` |
| [`4807351d`](https://github.com/NixOS/nixpkgs/commit/4807351d123543270d90da5a1100afd294ee9020) | `obs-studio: fix doublewrapping`                                                 |
| [`cfcabdb2`](https://github.com/NixOS/nixpkgs/commit/cfcabdb26887103c091a36cb4593f4bd8d8d0b39) | `vscode-extensions.davidlday.languagetool-linter: styling fixup`                 |
| [`bcf8e9f5`](https://github.com/NixOS/nixpkgs/commit/bcf8e9f50c10c4e3efe6c2ce3aadea15d55c6d47) | `buildah: 1.23.0 -> 1.23.1`                                                      |
| [`751ce748`](https://github.com/NixOS/nixpkgs/commit/751ce748bd1ebac94442dfeaa8bc3f100d73a9f6) | `friture: backport fix for setuptools packaging`                                 |
| [`5c81b881`](https://github.com/NixOS/nixpkgs/commit/5c81b8818709d736b9e52eb45efb237c80f732de) | `friture: use sed instead of patch`                                              |
| [`3b9943f4`](https://github.com/NixOS/nixpkgs/commit/3b9943f477304d9d128eee70b95c4fec6e0aff8d) | `friture: add myself as maintainer`                                              |
| [`ac0269c3`](https://github.com/NixOS/nixpkgs/commit/ac0269c3792db76ac074965f4da9f5566a3f7bb7) | `friture: 0.47 -> 0.48`                                                          |
| [`4da83b53`](https://github.com/NixOS/nixpkgs/commit/4da83b53d92714a51e9211eec7059f32046ca154) | `vscodium: 1.60.1 -> 1.60.2`                                                     |
| [`18185958`](https://github.com/NixOS/nixpkgs/commit/1818595870b6dd7889d2350b76424373d51b7a6c) | `gallery-dl: 1.18.4 -> 1.19.0`                                                   |
| [`77fc73dc`](https://github.com/NixOS/nixpkgs/commit/77fc73dc1e08a4337b08424423b27ee38908fbdb) | `shfmt: 3.3.1 -> 3.4.0`                                                          |
| [`7325f6a4`](https://github.com/NixOS/nixpkgs/commit/7325f6a4f14d19eeaf0129e7b52710d141a28b76) | `tor-browser-bundle-bin: Add eff.org mirror`                                     |
| [`3b8e97b4`](https://github.com/NixOS/nixpkgs/commit/3b8e97b4f721ef14846c43df4c82143977113156) | `libdecor: init at 0.1.0`                                                        |
| [`2925c777`](https://github.com/NixOS/nixpkgs/commit/2925c7770a95b01a49e110b25222fcf65d7c096b) | `packer: 1.7.5 -> 1.7.6 (#140205)`                                               |
| [`80efae7b`](https://github.com/NixOS/nixpkgs/commit/80efae7bb17ba8ac7236295df2e4fa0fe787f7eb) | `vault-bin: 1.8.2 -> 1.8.3`                                                      |
| [`bf1355c6`](https://github.com/NixOS/nixpkgs/commit/bf1355c60d84611877aec97f2917fbfa23d0cf18) | `vault: 1.8.2 -> 1.8.3`                                                          |
| [`b2f46b6e`](https://github.com/NixOS/nixpkgs/commit/b2f46b6e80c80953a64927bb9333cdef94ccbffe) | `brave: 1.30.86 -> 1.30.87`                                                      |
| [`ed2c99e6`](https://github.com/NixOS/nixpkgs/commit/ed2c99e65f4f5f4bf3bb3a3422f07fc8ec9a97ce) | `llvmPackages_13: 13.0.0-rc4 -> 13.0.0`                                          |
| [`ce50eda3`](https://github.com/NixOS/nixpkgs/commit/ce50eda3949fa3149aea4f0f556dbb63f48e4288) | `chromium: 94.0.4606.61 -> 94.0.4606.71`                                         |
| [`90883906`](https://github.com/NixOS/nixpkgs/commit/90883906aa220e834391affe412e0ebda4438736) | `tfsec: 0.58.11 -> 0.58.12`                                                      |
| [`360707c5`](https://github.com/NixOS/nixpkgs/commit/360707c5d67a16b26a881237024da3b9305f38aa) | `ungoogled-chromium: 94.0.4606.61 -> 94.0.4606.71`                               |
| [`2415e9a7`](https://github.com/NixOS/nixpkgs/commit/2415e9a70eb26a3960f87f083479a2ef419aca3e) | `htmltest: add ldflags`                                                          |
| [`729b06f8`](https://github.com/NixOS/nixpkgs/commit/729b06f84461e35a61b3161c26a30837638ced5e) | `htmltest: 0.14.0 -> 0.15.0`                                                     |
| [`00a5d017`](https://github.com/NixOS/nixpkgs/commit/00a5d0172c8a5fa1df573f44b387ad662083fabc) | `pkgs/development/libraries/audio: enable build on darwin`                       |
| [`cc57077a`](https://github.com/NixOS/nixpkgs/commit/cc57077ac52df9fc03e81ddfd314651eeca2bc38) | `vscode-extensions.davidlday.languagetool-linter: init at 0.18.0`                |
| [`9bcab4e7`](https://github.com/NixOS/nixpkgs/commit/9bcab4e72cc494d6129fa68d48e87f4fbaa4df27) | `maintainers: add ebbertd`                                                       |
| [`9ad5029b`](https://github.com/NixOS/nixpkgs/commit/9ad5029b7195b7314f30367b6ab30ea994529056) | `helm: fix #79177 on linux (#137146)`                                            |
| [`5fe9f36a`](https://github.com/NixOS/nixpkgs/commit/5fe9f36a37f652fb4f27a47f55dfafca0610410b) | `python3Packages.pysiaalarm: 3.0.1 -> 3.0.2`                                     |
| [`5d53e38d`](https://github.com/NixOS/nixpkgs/commit/5d53e38d24fa8db1ad684cd7bd1d6e4ef1756ab1) | `nixos/gitea: switch default log level to Info`                                  |
| [`10703a8c`](https://github.com/NixOS/nixpkgs/commit/10703a8c926e182311cdf538937517db33f4261c) | `nixos/nextcloud: run tests against each Nextcloud instance`                     |
| [`66edc1e8`](https://github.com/NixOS/nixpkgs/commit/66edc1e84625ed5b4bed5868f4093a570a822c2e) | `nixos/nextcloud: use php8 where possible`                                       |
| [`4c2579ed`](https://github.com/NixOS/nixpkgs/commit/4c2579ed946e7c9bd370d1c0851e8c98980d09da) | `pamixer: 1.4 -> unstable-2021-03-29`                                            |
| [`ac5f1cc4`](https://github.com/NixOS/nixpkgs/commit/ac5f1cc451ef2ce39779164f0858b58e25b0ef8f) | `kalker: 1.0.0 -> 1.0.1-2`                                                       |
| [`2575999f`](https://github.com/NixOS/nixpkgs/commit/2575999f41e9d4d19289a50325f390e09be0b0b4) | `watchexec: 1.15.1 -> 1.17.1`                                                    |
| [`c632d826`](https://github.com/NixOS/nixpkgs/commit/c632d826a3b46e99ee14c15945cd8a758e74d4a1) | `lxd: 4.18 -> 4.19`                                                              |
| [`32435191`](https://github.com/NixOS/nixpkgs/commit/324351910baf45dc049bbd01d1d72b8cb2c4edac) | `difftastic: 0.9 -> 0.10.1`                                                      |
| [`45c04e26`](https://github.com/NixOS/nixpkgs/commit/45c04e261c7d13cda5346c8e2bb61a7cb7307d8f) | `postgresql11Packages.age: 0.2.0 -> 0.6.0`                                       |
| [`04084d9e`](https://github.com/NixOS/nixpkgs/commit/04084d9e7ce43208cf0645485b05d40e09cda6d4) | `docker-slim: 1.36.4 -> 1.37.0`                                                  |
| [`b3da92cd`](https://github.com/NixOS/nixpkgs/commit/b3da92cdd3ce2328ca530f100ab6fecee88e4d93) | `postgresqlPackages.pg_bigm: 1.2 -> 1.2-20200228`                                |
| [`b8a21651`](https://github.com/NixOS/nixpkgs/commit/b8a216518cbedaddff2f0a540dab91a3fcb863c6) | `postgresqlPackages.pgrouting: 3.1.3 -> 3.2.1`                                   |
| [`10d7fe6d`](https://github.com/NixOS/nixpkgs/commit/10d7fe6d7fd141b85ac585c1f328e5490c6fe223) | `postgresqlPackages.plr: 8.4.1 -> 8.4.4`                                         |
| [`af9b4c3a`](https://github.com/NixOS/nixpkgs/commit/af9b4c3aee844f1948e9e87d82106424c59949b7) | `multus-cni: fix version ouput, clean up`                                        |
| [`a30041c1`](https://github.com/NixOS/nixpkgs/commit/a30041c1a4a6299148614ad73e601b147a32b4d2) | `python3Packages.collections-extended: init at 2.0.0`                            |
| [`3f012da9`](https://github.com/NixOS/nixpkgs/commit/3f012da95b16f829b20f4370a99304980377ef12) | `linuxKernel.kernels.linux_xanmod: 5.14.8 -> 5.14.9`                             |
| [`2cacbfd2`](https://github.com/NixOS/nixpkgs/commit/2cacbfd2ca831933d996c9defb05bb2b4a013d6b) | `podman: 3.3.1 -> 3.4.0`                                                         |
| [`37142f3c`](https://github.com/NixOS/nixpkgs/commit/37142f3c309e41553695fdd1ea72cd75ea887896) | `python3Packages.restfly: 1.4.1 -> 1.4.2`                                        |
| [`dde4e813`](https://github.com/NixOS/nixpkgs/commit/dde4e813d329c6db19dcc4c988927629739ce115) | `visidata: 2.6 -> 2.6.1`                                                         |
| [`56ebbc49`](https://github.com/NixOS/nixpkgs/commit/56ebbc49e79ebd15d29d961c571e976ec8bc0d04) | `pipewire: 0.3.37 -> 0.3.38`                                                     |
| [`2e0dc260`](https://github.com/NixOS/nixpkgs/commit/2e0dc26070c33a2a84275ea0fef827f5b1b88c75) | `metasploit: add wrappers for pattern_create/offset`                             |
| [`3a9ffac1`](https://github.com/NixOS/nixpkgs/commit/3a9ffac149446f885ac533025a10a84f64db836a) | `varnish70: fix build on darwin`                                                 |
| [`145f628f`](https://github.com/NixOS/nixpkgs/commit/145f628f69224b9393b831ca2749b6a86ed0a9ff) | `varnish65*: drop because it is EOL upstream`                                    |
| [`83261624`](https://github.com/NixOS/nixpkgs/commit/83261624ae76a72719633b05911da9a9cbdfa3ab) | `varnish60: 6.0.7 -> 6.0.8`                                                      |
| [`eba8f7e3`](https://github.com/NixOS/nixpkgs/commit/eba8f7e3d5ccb29e617baadb7580e600a2b326db) | `varnish70: init at 7.0.0`                                                       |
| [`9b3b8f74`](https://github.com/NixOS/nixpkgs/commit/9b3b8f74bb974dcb7ecbfe2730296217532e3a42) | `fix nested calls to extendDerivation`                                           |
| [`4467ba61`](https://github.com/NixOS/nixpkgs/commit/4467ba610121463a327dbeb1669e81e30387d3c4) | `sbcl_2_1_9: init at 2.1.9`                                                      |
| [`8ed16161`](https://github.com/NixOS/nixpkgs/commit/8ed16161577d4ba2e570654cfaaeae479d7ed79e) | `sbcl_2_1_8: remove at 2.1.8`                                                    |
| [`8e1d60e3`](https://github.com/NixOS/nixpkgs/commit/8e1d60e39ce66b26bca2990353262a55ae348fc0) | `notmuch: 0.33 -> 0.33.2`                                                        |
| [`22f86132`](https://github.com/NixOS/nixpkgs/commit/22f86132177b7eac7614a73eda8613b18c41b276) | `python38Packages.cornice: 5.2.0 -> 6.0.0`                                       |
| [`2fd4fbe8`](https://github.com/NixOS/nixpkgs/commit/2fd4fbe86676420efd22e44b9476fe9539d80926) | `rar: add support to x86_64-darwin`                                              |
| [`357a548c`](https://github.com/NixOS/nixpkgs/commit/357a548c122a46e55f2e30a21687c776ff1f6354) | `python38Packages.casbin: 1.9.1 -> 1.9.2`                                        |
| [`2d1cfc58`](https://github.com/NixOS/nixpkgs/commit/2d1cfc588248909680b6800dc26d0c1385287092) | `vimPlugins.markdown-preview-nvim: fix node dependencies`                        |
| [`9db14723`](https://github.com/NixOS/nixpkgs/commit/9db14723ded093c2fb60c6e39ebb3bd479ae0c8f) | `python38Packages.sagemaker: 2.57.0 -> 2.59.4`                                   |
| [`24f7f9d5`](https://github.com/NixOS/nixpkgs/commit/24f7f9d594c4083ae0be753d8a68f0d9ab2b8c1f) | `python3Packages.pipx: 0.16.3 -> 0.16.5`                                         |
| [`3b67f552`](https://github.com/NixOS/nixpkgs/commit/3b67f5520144d139c4b7e08cd09be8c8dc7cb4c9) | `python38Packages.google-cloud-bigtable: 2.3.3 -> 2.4.0`                         |
| [`f70860c9`](https://github.com/NixOS/nixpkgs/commit/f70860c9dcb7156f1cb81b45390cf71322f5da11) | `python3Packages.rapidfuzz: 1.6.2 -> 1.7.0`                                      |
| [`8fc2bda3`](https://github.com/NixOS/nixpkgs/commit/8fc2bda3c44fe57c309b394d69dd051c57e01080) | `python38Packages.pathvalidate: 2.4.1 -> 2.5.0`                                  |
| [`44881966`](https://github.com/NixOS/nixpkgs/commit/44881966286c672a8674456080d5cf0f4a0f73c1) | `pipewire: add libcamera support`                                                |
| [`a8d0ad62`](https://github.com/NixOS/nixpkgs/commit/a8d0ad62cb2144c14f17aa7580eec48b63484f85) | `libcamera: unstable-2021-06-02 -> unstable-2021-09-24`                          |