### PR TITLE
chore(deps): update nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f91fec348dd7e6da0bb222c9470c7d1046dcec78",
-        "sha256": "0kl6cz81z0jc6kzpwlbn4r2dpn25sfdvq3jykhbrbx43l4hxkz1k",
+        "rev": "6d7a5212c5c2cb8a873477927078ed53a028307b",
+        "sha256": "0xcd9527qcak0g06n4xnaz76gzj9m6x5gfnqmsq9rapjvmxinnhv",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f91fec348dd7e6da0bb222c9470c7d1046dcec78.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/6d7a5212c5c2cb8a873477927078ed53a028307b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "poetry2nix": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`f74fb8c4`](https://github.com/NixOS/nixpkgs/commit/f74fb8c45d4d41f8cac6594f6b2eb8bd1278a708) | `crowdin-cli: 3.7.0 -> 3.7.1`                                                                    |
| [`0b0d2637`](https://github.com/NixOS/nixpkgs/commit/0b0d2637fca96a4e4d7fac4c40e0773bc218ff53) | `Revert "nixos/specialisation: Rephrase in terms of extendModules, noUserModules"`               |
| [`e2bea442`](https://github.com/NixOS/nixpkgs/commit/e2bea4427bcf03ae168e45e0bcbd92ac678d91ce) | `nixos/specialisation: Rephrase in terms of extendModules, noUserModules`                        |
| [`86f5136b`](https://github.com/NixOS/nixpkgs/commit/86f5136bafec4a6208ffe23e870f74c731f849de) | `modules: Update evalModules doc`                                                                |
| [`22584ce6`](https://github.com/NixOS/nixpkgs/commit/22584ce6675fdabd14fd71f7ce8021cd14facf05) | `nixos/eval-config.nix: Expose type`                                                             |
| [`64dfd983`](https://github.com/NixOS/nixpkgs/commit/64dfd983df61d9c427ac01d0d25b8d2f26b4c3d5) | `modules: Add visible = "shallow" to hide only sub-options`                                      |
| [`27644a82`](https://github.com/NixOS/nixpkgs/commit/27644a82a99b4855e40dfd6c09d7288664217662) | `modules: Add extendModules to module args`                                                      |
| [`dece37b8`](https://github.com/NixOS/nixpkgs/commit/dece37b83a46d488787859332e18286727b96cc4) | `lib.evalModules: Add extendModules and type to result`                                          |
| [`9ec2134b`](https://github.com/NixOS/nixpkgs/commit/9ec2134b6864019849f4fc267ecab6ddd88e9cea) | `statix: 0.3.1 -> 0.3.4`                                                                         |
| [`8d8a17f8`](https://github.com/NixOS/nixpkgs/commit/8d8a17f889e7df0b7742505ea87ee4dce1a83433) | `lemmy: 0.12.2 -> 0.13.3`                                                                        |
| [`f1d3cdcf`](https://github.com/NixOS/nixpkgs/commit/f1d3cdcf58803275486579e3e088d4d333672eff) | `lemmy: use pin.json to prepare for update script`                                               |
| [`9a3e6e22`](https://github.com/NixOS/nixpkgs/commit/9a3e6e22534e51dc68bd80730df5ad54e2aaa521) | `lemmy-ui: use fetchyarndeps`                                                                    |
| [`c0b0059e`](https://github.com/NixOS/nixpkgs/commit/c0b0059e8a4ffd9189f318afb2d16ca78bb415cc) | `ns-3: 3.34 -> 3.35`                                                                             |
| [`7638773c`](https://github.com/NixOS/nixpkgs/commit/7638773c6a5d9ec7d058d057367bb64c05eed934) | `vimPlugins.lingua-franca: init at 2021-9-5 (#144040)`                                           |
| [`714db3b5`](https://github.com/NixOS/nixpkgs/commit/714db3b557bf98498143a4ac4d9e68f66817bec6) | `qimgv: 1.0.1 -> 1.0.2`                                                                          |
| [`a13b5c3e`](https://github.com/NixOS/nixpkgs/commit/a13b5c3ecb96c0332017fa01eb3a6e3a83711fc2) | `maintainers: add matrix id for ekleog (#144050)`                                                |
| [`11a1d227`](https://github.com/NixOS/nixpkgs/commit/11a1d227b28121732a771b3ef2b973ada3dcfc00) | `weylus: 0.11.3 -> 0.11.4`                                                                       |
| [`ec051184`](https://github.com/NixOS/nixpkgs/commit/ec051184292886757d567ffe9fe09be7b97f92bc) | `clpm: 0.3.6 -> 0.4.1 (#143163)`                                                                 |
| [`78709f61`](https://github.com/NixOS/nixpkgs/commit/78709f61dad7bdebfaa1403ae841a3f937a75861) | `entangle: init at 3.0`                                                                          |
| [`a1bbe130`](https://github.com/NixOS/nixpkgs/commit/a1bbe1306e4d09567d50b8b4ab5bcfbf43743b4e) | `SHADERed: 1.4.1 -> 1.5.6 (#143915)`                                                             |
| [`f990fb9f`](https://github.com/NixOS/nixpkgs/commit/f990fb9fcbdd7c2fb20f8e13206de0e4606337da) | `python38Packages.skorch: 0.10.0 -> 0.11.0`                                                      |
| [`4bdb1450`](https://github.com/NixOS/nixpkgs/commit/4bdb1450539bc8da526be187153b3c1fa8339e42) | `rakudo: fix darwin sharedLibrary path`                                                          |
| [`925ab444`](https://github.com/NixOS/nixpkgs/commit/925ab444c96020343f265a0e7531e991158234f8) | `elan: 1.1.0 -> 1.2.0`                                                                           |
| [`7bbd7efd`](https://github.com/NixOS/nixpkgs/commit/7bbd7efdcb03379dea0a42aeafc25b06508cc336) | `python39Packages.pep257: cleanup`                                                               |
| [`955a657d`](https://github.com/NixOS/nixpkgs/commit/955a657de4206c4270182ca6468c2dfbebd7415b) | `python39Packages.livestreamer: cleanup, remove python2`                                         |
| [`7615b74c`](https://github.com/NixOS/nixpkgs/commit/7615b74cb1b37cbdb619ea9b852e334ac4dfd7db) | `python39Packages.livestreamer-curses: cleanup`                                                  |
| [`205903c9`](https://github.com/NixOS/nixpkgs/commit/205903c9928856e698a1c6660531972f6346bf63) | `python39Packages.audiotools: cleanup`                                                           |
| [`4fa7ac22`](https://github.com/NixOS/nixpkgs/commit/4fa7ac22c48d78b8cbdd931adcb728289a76a1d8) | `nixosTests.cifs-utils: remove`                                                                  |
| [`dedb0147`](https://github.com/NixOS/nixpkgs/commit/dedb014786c097138392f548bea5a9867c2eea9d) | `python3Packages.importlib-resources: 5.2.2 -> 5.4.0`                                            |
| [`eb7d94e6`](https://github.com/NixOS/nixpkgs/commit/eb7d94e6e3adb3b73b7969ce549f1a5dff65c84c) | `sublime{4,-merge}: Update packages.`                                                            |
| [`3d313212`](https://github.com/NixOS/nixpkgs/commit/3d313212052b415695de4a0737d4dad6c24bd6e4) | `tree-sitter: use CXX to compile C++, optimize and strip`                                        |
| [`f7211380`](https://github.com/NixOS/nixpkgs/commit/f7211380906aa60e42007b656240c126ba4d2e91) | `ssh-tools: 1.6 -> 1.7`                                                                          |
| [`62453006`](https://github.com/NixOS/nixpkgs/commit/62453006868b0adfc8eb7fa0d3701cbab78d429c) | `python3Packages: add pkgs. prefix`                                                              |
| [`0d127542`](https://github.com/NixOS/nixpkgs/commit/0d127542671c99e45de4e355592a25e955daac4a) | `python3Packages.icmplib: 3.0.1 -> 3.0.2`                                                        |
| [`059feb3c`](https://github.com/NixOS/nixpkgs/commit/059feb3ccf8f87b3b93bfdd164ab1e43e0298645) | `honcho: 1.0.1 -> 1.1.0, fix the package`                                                        |
| [`6954a396`](https://github.com/NixOS/nixpkgs/commit/6954a396d11feaa1f543fccd3b994ed3db258d26) | `Revert "build(deps): bump zeebe-io/backport-action from 0.0.5 to 0.0.6 (#140848)"`              |
| [`a8ac0dd9`](https://github.com/NixOS/nixpkgs/commit/a8ac0dd94475e5b061adb1e7658151eb2f1186e2) | `Revert "backport-action: 0.0.6 -> 0.0.7"`                                                       |
| [`56c4f9d0`](https://github.com/NixOS/nixpkgs/commit/56c4f9d0052c60aba6b2b8a8a7976cc3f808000d) | `nixosTest: Fix infinite recursion involving hasContext testScript when useNixStoreImage = true` |
| [`9f72692d`](https://github.com/NixOS/nixpkgs/commit/9f72692d125b8a5dc0684a36bf6ffff0774deab3) | `python38Packages.netcdf4: 1.5.7 -> 1.5.8`                                                       |
| [`aad67bd9`](https://github.com/NixOS/nixpkgs/commit/aad67bd968aace87be59fa63858a5810d35f5b82) | `perlPackages.CompressRawLzma: init at 2.101 (#142679)`                                          |
| [`e4e3fbe8`](https://github.com/NixOS/nixpkgs/commit/e4e3fbe8aa4f3a610de91c047b3ea71debeb104e) | `nixos/tests/ghostunnel.nix: Fix eval as invoked by release.nix`                                 |
| [`1d525f51`](https://github.com/NixOS/nixpkgs/commit/1d525f51fbc2f535b7bf4d1d35dafccda7f1f3ed) | `yarn2nix: add nix-prefetch-git to PATH`                                                         |
| [`7bec5411`](https://github.com/NixOS/nixpkgs/commit/7bec54111767242a57bc49bb760bff2ef075a3ca) | `yarn2nix: no sha1 for github tarballs`                                                          |
| [`c78c75ad`](https://github.com/NixOS/nixpkgs/commit/c78c75ad737595999e5dfc46591c18ca772909bd) | `python3Packages: normalise package names in aliases`                                            |
| [`e04b3dc3`](https://github.com/NixOS/nixpkgs/commit/e04b3dc3072c87077f61e624a0c52d6402965cdf) | `python39Packages.lammps-cython: normalise name`                                                 |
| [`2de4ddaf`](https://github.com/NixOS/nixpkgs/commit/2de4ddafcafb1983f3c8588d2a7964bf0ffe61aa) | `python3Packages.iso3166: 1.0.1 -> 2.0.2`                                                        |
| [`78cf2dda`](https://github.com/NixOS/nixpkgs/commit/78cf2dda334ec1ed52bd81d62f10f153bad89a31) | `nixosTests.nixops: Fix deprecation warning`                                                     |
| [`8e353417`](https://github.com/NixOS/nixpkgs/commit/8e35341711fafeaf758807506ef9c616e869b884) | `python38Packages.scikit-survival: 0.15.0.post0 -> 0.16.0`                                       |
| [`195845a1`](https://github.com/NixOS/nixpkgs/commit/195845a10c8f4e99fe83c6d12c96ab3c1ee0377c) | `ocamlPackages.ocaml-top: subsitute version`                                                     |
| [`db200332`](https://github.com/NixOS/nixpkgs/commit/db2003322d7ed7707e7b5516bade23f3b61b93f5) | `python3Packages.ibis: 1.6.0 -> 3.2.0`                                                           |
| [`c1a74608`](https://github.com/NixOS/nixpkgs/commit/c1a746083b6dde8859cd5184f30045d98617d7d0) | `python39Packages.pyspotify: cleanup`                                                            |
| [`ee62f3ea`](https://github.com/NixOS/nixpkgs/commit/ee62f3ea0a1375ec16f5e91eb9d5ab1259951936) | `python39Packages.pycangjie: fix version format`                                                 |
| [`b90d3b02`](https://github.com/NixOS/nixpkgs/commit/b90d3b02a3061d24d80ee9826da6ee4a1e673f1a) | `imagemagick: 7.1.0-11 -> 7.1.0-13`                                                              |
| [`0995b30c`](https://github.com/NixOS/nixpkgs/commit/0995b30c341709660ff25b598e0a52f37e119bae) | `nix-du: 0.3.3 -> 0.4`                                                                           |
| [`58fda166`](https://github.com/NixOS/nixpkgs/commit/58fda166ed4a7e2540dea07a3ce0d9127cc95d16) | `kitty: fix fontconfig warning during tests`                                                     |
| [`8c938b43`](https://github.com/NixOS/nixpkgs/commit/8c938b431923ee2823ccf84e64a1f88afd85cb78) | `btcpayserver: 1.2.4 -> 1.3.1`                                                                   |
| [`e198a1d7`](https://github.com/NixOS/nixpkgs/commit/e198a1d720dcebce24b136effd009dcebdfbec0c) | `msmtp: 1.8.17 -> 1.8.18`                                                                        |
| [`5e1c94ef`](https://github.com/NixOS/nixpkgs/commit/5e1c94effd0ea9696376dd5c9ab325a2d76514d5) | `neomutt: 20211022 -> 20211029`                                                                  |
| [`16e7aa7e`](https://github.com/NixOS/nixpkgs/commit/16e7aa7e7f131e47e0598f070b2e8cf6889e21cb) | `mpop: 1.4.15 -> 1.4.16`                                                                         |
| [`13fad0f8`](https://github.com/NixOS/nixpkgs/commit/13fad0f81b2bd50fd421bd5856a35f1f7c032257) | `nixos/systemd-boot: create boot entries for specialisations`                                    |
| [`0182d404`](https://github.com/NixOS/nixpkgs/commit/0182d4040348dbe481bc5e897cc504e0134fd6e3) | `sedutil: 1.15.1 -> 1.20.0`                                                                      |
| [`c348f7c1`](https://github.com/NixOS/nixpkgs/commit/c348f7c17d9960b618252db428aa3612dd0ee856) | `gnome.tali: 40.3 → 40.4`                                                                        |
| [`78946b0e`](https://github.com/NixOS/nixpkgs/commit/78946b0e98230a1eea6660645250b1fccc62e58a) | `gnome.nautilus: 41.0 → 41.1`                                                                    |
| [`1ae58eb5`](https://github.com/NixOS/nixpkgs/commit/1ae58eb531b9dca930f2270df9c0a910d69e9d6c) | `gnome.libgnome-games-support: 1.8.1 → 1.8.2`                                                    |
| [`a3dca903`](https://github.com/NixOS/nixpkgs/commit/a3dca903bb0d551b234f1889471156026af9ecfb) | `gnome.gnome-terminal: 3.42.0 → 3.42.1`                                                          |
| [`d984d321`](https://github.com/NixOS/nixpkgs/commit/d984d321b4834f73013b528791478b8f6b820253) | `gnome.gnome-remote-desktop: 41.0 → 41.1`                                                        |
| [`7508b25a`](https://github.com/NixOS/nixpkgs/commit/7508b25ad0c4cc51bd72603f373d1573f86f4e33) | `gnome.gnome-maps: 41.0 → 41.1`                                                                  |
| [`467f55e8`](https://github.com/NixOS/nixpkgs/commit/467f55e87ea47362ba3f2d5d804e5a9d3496bef8) | `gnome.gnome-chess: 41.0 → 41.1`                                                                 |
| [`81271ee4`](https://github.com/NixOS/nixpkgs/commit/81271ee4c12eab7c55615ef6f2538bbd3691fd8b) | `gnome.gnome-autoar: 0.4.0 → 0.4.1`                                                              |
| [`1e715d10`](https://github.com/NixOS/nixpkgs/commit/1e715d10b2e31b67453aa4469c0eb40f4fed9903) | `numix-icon-theme: 21.04.14 -> 21.10.31`                                                         |
| [`957284c6`](https://github.com/NixOS/nixpkgs/commit/957284c69017d6e9dabd655b1897ab02491d54ca) | `sniffglue: 0.13.1 -> 0.14.0`                                                                    |
| [`169a096d`](https://github.com/NixOS/nixpkgs/commit/169a096d26ae7430ded196ecd75ae06c339cf4e6) | `leftwm: 0.2.8 -> 0.2.9`                                                                         |
| [`486ca523`](https://github.com/NixOS/nixpkgs/commit/486ca523c92ded007a0927ed050d10d3631560f9) | `python38Packages.django-storages: 1.12.2 -> 1.12.3`                                             |
| [`dd4e65d6`](https://github.com/NixOS/nixpkgs/commit/dd4e65d6201106fa0e90aede42f743c3b8b4ed89) | `gnome.aisleriot: 3.22.17 → 3.22.19`                                                             |
| [`a5d70a83`](https://github.com/NixOS/nixpkgs/commit/a5d70a83eb38e87dba9387164f86fc5e5812203c) | `gnome-recipes: 2.0.2 → 2.0.4`                                                                   |
| [`a20a4af6`](https://github.com/NixOS/nixpkgs/commit/a20a4af62aee6f338f81cd16e988bea3878adf59) | `maintainers/scripts/update.nix: Support committing with nix-update-script`                      |
| [`fb9c102b`](https://github.com/NixOS/nixpkgs/commit/fb9c102b54ac17cc31618e99a57f5ce9fe94f63f) | `python38Packages.libtmux: 0.10.1 -> 0.10.2`                                                     |
| [`0f44ce8d`](https://github.com/NixOS/nixpkgs/commit/0f44ce8d58189d572f0e52883737c25699029f42) | `jc: 1.17.0 -> 1.17.1`                                                                           |
| [`f270c529`](https://github.com/NixOS/nixpkgs/commit/f270c529ce51cb462db2331629dcee64879dfdf5) | `dleyna-renderer: 0.7.1 → 0.7.2`                                                                 |
| [`ae3dc2d9`](https://github.com/NixOS/nixpkgs/commit/ae3dc2d9749ff2ea1f6cafacb509b0e14c73faa2) | `dleyna-server: 0.7.1 → 0.7.2`                                                                   |
| [`12fbbf35`](https://github.com/NixOS/nixpkgs/commit/12fbbf3500d1d8514a1774fe5cb837ed0b20d006) | `meteo: 0.9.8 -> 0.9.9`                                                                          |
| [`e6d69fa2`](https://github.com/NixOS/nixpkgs/commit/e6d69fa20ede8a37a71cbd3d93483b09b7448e31) | `trash-cli: 0.21.7.24 -> 0.21.10.24`                                                             |
| [`069d3c8a`](https://github.com/NixOS/nixpkgs/commit/069d3c8abd626a8a2d3e8e6db51d42cfbedb9a7b) | `python3Packages.angrcli: init at 1.1.1`                                                         |
| [`54c353d0`](https://github.com/NixOS/nixpkgs/commit/54c353d0b0173abb3337b491d18e7cadd47c4ad9) | `python38Packages.base58: 2.1.0 -> 2.1.1`                                                        |
| [`597eb07e`](https://github.com/NixOS/nixpkgs/commit/597eb07e00d7173ec8f7287e54080715e608df4f) | `yices: drop symlink hack, avoid ldconfig on linux`                                              |
| [`5ce69b0b`](https://github.com/NixOS/nixpkgs/commit/5ce69b0b2db2e669f6bca44a6f9e31238f43a20b) | `esbuild: 0.13.10 -> 0.13.11`                                                                    |
| [`f136a08a`](https://github.com/NixOS/nixpkgs/commit/f136a08a3bfa2cc6fb7d969fbcfa583a95ec0bf0) | `python3Packages.upass: add pythonImportsCheck`                                                  |
| [`ad6ad9af`](https://github.com/NixOS/nixpkgs/commit/ad6ad9af78b44025c99865b3139dd3ce9a21cb56) | `python38Packages.upass: 0.1.4 -> 0.2.1`                                                         |
| [`0e1318f8`](https://github.com/NixOS/nixpkgs/commit/0e1318f826a7320c7dd0db3bc3160ee583d61357) | `python3Packages.pex: add pythonImportsCheck`                                                    |
| [`a2445c74`](https://github.com/NixOS/nixpkgs/commit/a2445c740efa0f5a34c1756dd28812e1b12d0b24) | `coqPackages.dpdgraph: 0.6.9 → 1.0`                                                              |
| [`674eb91f`](https://github.com/NixOS/nixpkgs/commit/674eb91f4cad2d0cce67b3e8e6080b409c45f0e2) | `python38Packages.aenum: 3.1.0 -> 3.1.1`                                                         |
| [`44883e70`](https://github.com/NixOS/nixpkgs/commit/44883e70cc9b40d104d3a1cbdd7b576815aa08e0) | `quaternion: 0.0.95 - 0.0.95.1`                                                                  |
| [`2cfa8b55`](https://github.com/NixOS/nixpkgs/commit/2cfa8b5511381f629abd0cec2ff5e8c988ec0298) | `libquotient: 0.6.9 -> 0.6.11`                                                                   |
| [`19c1eb37`](https://github.com/NixOS/nixpkgs/commit/19c1eb3710c5de9ff23f3e928e552bc703886b95) | `ttyd: enable on darwin`                                                                         |
| [`674a09e6`](https://github.com/NixOS/nixpkgs/commit/674a09e6c2d853919e73139b489aa64ba5f70203) | `acpica-tools: 20210730 -> 20210930`                                                             |
| [`36e0ff5f`](https://github.com/NixOS/nixpkgs/commit/36e0ff5fedec8c1c901cd44b97870e7188d47c6a) | `logseq: 0.4.2 -> 0.4.5`                                                                         |
| [`f8f15d06`](https://github.com/NixOS/nixpkgs/commit/f8f15d06acdc439795923139eb9cea1e3f2f55cf) | `python38Packages.pex: 2.1.52 -> 2.1.53`                                                         |
| [`b232c81a`](https://github.com/NixOS/nixpkgs/commit/b232c81a32c78ab1c2e4b13796a8149a375b6df7) | `virtualbox: 6.1.26 -> 6.1.28`                                                                   |
| [`27ba20dd`](https://github.com/NixOS/nixpkgs/commit/27ba20dd72d523656b4aec6ce46f7c5dffb09dd4) | `linuxPackages.vm-tools: init`                                                                   |
| [`788920fc`](https://github.com/NixOS/nixpkgs/commit/788920fcdf8fff2fb3eb0a70d00822a45ecd454f) | `nixosTests.rasdaemon: init module test`                                                         |
| [`e1437878`](https://github.com/NixOS/nixpkgs/commit/e14378789c9d8fe571980af14cbdcd31cdca06b6) | `nixos/rl-2111: add new service: rasdaemon`                                                      |
| [`b6ff276f`](https://github.com/NixOS/nixpkgs/commit/b6ff276fb18991c71dd2a2e05ea81c9055cb908d) | `nixos/rasdaemon: init module`                                                                   |
| [`ea0e9dac`](https://github.com/NixOS/nixpkgs/commit/ea0e9dac2a8de2c6cd67507c41c8f915557eafc1) | `error-inject: init mce, edac and aer`                                                           |
| [`93f3805d`](https://github.com/NixOS/nixpkgs/commit/93f3805d8847b6fdfcc06022841c3274066df522) | `rasdaemon: init at 0.6.7`                                                                       |
| [`91bab151`](https://github.com/NixOS/nixpkgs/commit/91bab1510b668e7b9d18f0d77e52674780c91146) | `gitRepo: 2.17.2 -> 2.17.3`                                                                      |
| [`12fe0fae`](https://github.com/NixOS/nixpkgs/commit/12fe0fae03d81be4843ba2e34bc5fb07a0a3ea9e) | `arrow-cpp: 5.0.0 -> 6.0.0 (#143422)`                                                            |
| [`7237eb40`](https://github.com/NixOS/nixpkgs/commit/7237eb405e1442b318d1d2aa0e2508d5a5b71f73) | `getmail6: 6.18.4 -> 6.18.5`                                                                     |
| [`eab875b0`](https://github.com/NixOS/nixpkgs/commit/eab875b05748b68131a8920d91549574a337f297) | `flexget: 3.1.148 -> 3.1.149`                                                                    |
| [`cadbf505`](https://github.com/NixOS/nixpkgs/commit/cadbf50512ed03be55b395110ffbfe27f0aa3b82) | `vimPlugins.lean-nvim: init at 2021-10-30`                                                       |
| [`cb8398c8`](https://github.com/NixOS/nixpkgs/commit/cb8398c8171a1b473f76da223bb3f91fd39a4347) | `pantheon.elementary-videos: 2.7.3 -> 2.8.0`                                                     |
| [`e93b752b`](https://github.com/NixOS/nixpkgs/commit/e93b752b9ee784385a75f1a55cbbf33264f40b2f) | `pantheon.elementary-default-settings: 6.0.1 -> 6.0.2`                                           |
| [`e8cf60ff`](https://github.com/NixOS/nixpkgs/commit/e8cf60ffb47ea21e90e208ae54a72a4a7140250f) | `pantheon.wingpanel-indicator-datetime: 2.3.0 -> 2.3.1`                                          |