### PR TITLE
feat: add support for python 3.10

### DIFF
--- a/.github/workflows/auto-rebase.yml
+++ b/.github/workflows/auto-rebase.yml
@@ -10,7 +10,7 @@ on:
       - labeled
 
 jobs:
-  auto-rebase:
+  autorebase:
     runs-on: ubuntu-latest
     steps:
       - uses: tibdex/github-app-token@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,29 +18,43 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-10.15
-          - macos-11
+          - macos-latest
         python-version:
           - "37"
           - "38"
           - "39"
+          - "310"
         exclude:
-          - os: macos-11
+          - os: macos-latest
             python-version: "37"
+
+            # 3.10 cannot be built with nixos-unstable-small as of 2022-01-14
+          - os: macos-latest
+            python-version: "310"
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+
       - uses: cachix/install-nix-action@v16
         with:
           nix_path: nixpkgs=channel:nixos-unstable-small
+
       - uses: cachix/cachix-action@v10
         with:
           name: numbsql
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
           extraPullNames: nix-community,poetry2nix
 
-      - run: nix build -L --keep-going '.#numbsql${{ matrix.python-version }}' --no-link
-      - run: nix path-info -Shr '.#numbsql${{ matrix.python-version }}'
+      - name: build and test
+        run: nix build --no-link --keep-going '.#numbsql${{ matrix.python-version }}'
+
+      - name: show closure size
+        run: |
+          set -euo pipefail
+
+          nix path-info -Shr '.#numbsql${{ matrix.python-version }}' | sort -h -k2
+
   conda:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -60,37 +74,63 @@ jobs:
           - numba: null
             llvmlite: null
         include:
-          - os: macos-10.15
-            python-version: "3.7.1"
-            # 3.7.5 is the oldest Python 3.7 available from the setup-python
-            # action
-            #
-            # see
-            # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
+          # 3.7.5 is the oldest Python 3.7 available from the setup-python
+          # action
+          #
+          # see
+          # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
           - os: windows-latest
             python-version: "3.7.5"
+            deps:
+              numba: "0.53"
+              llvmlite: "0.36"
+
+          - os: windows-latest
+            python-version: "3.7.5"
+            deps:
+              numba: null
+              llvmlite: null
         exclude:
           # macos-11 isn't supported on 3.7.x
           - os: macos-latest
             python-version: "3.7.1"
+            deps:
+              numba: null
+              llvmlite: null
+
+          - os: macos-latest
+            python-version: "3.7.1"
+            deps:
+              numba: "0.53"
+              llvmlite: "0.36"
           # windows + 3.7.1 has memory access violations, likely due to an
           # incompatible sqlite binary + python libsqlite library version
           #
           # these are the kinds of errors that will keep you up at night
           - os: windows-latest
             python-version: "3.7.1"
+            deps:
+              numba: null
+              llvmlite: null
+
+          - os: windows-latest
+            python-version: "3.7.1"
+            deps:
+              numba: "0.53"
+              llvmlite: "0.36"
     defaults:
       run:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
+        id: install_python
         with:
           python-version: ${{ matrix.python-version }}
 
       - run: pip3 install poetry2conda poetry
 
-      - run: poetry add --lock "numba@${{ matrix.deps.numba }}" "llvmlite@${{ matrix.deps.llvmlite }}"
+      - run: poetry add --lock "numba@${{ matrix.deps.numba }}" "llvmlite@${{ matrix.deps.llvmlite }}" --python "${{ steps.install_python.outputs.python-version }}"
         if: ${{ matrix.deps.numba != null && matrix.deps.llvmlite != null }}
 
       - run: poetry2conda --dev pyproject.toml - | tee environment.yaml
@@ -107,11 +147,32 @@ jobs:
 
       - run: pip install .
       - run: pytest --numprocesses auto
+
+  dry-run-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable-small
+
+      - uses: cachix/cachix-action@v10
+        with:
+          name: numbsql
+          extraPullNames: nix-community,poetry2nix
+
+      - name: dry run semantic-release
+        run: ./ci/release/dry_run.sh
+
   release:
     runs-on: ubuntu-latest
     needs:
-      - nix
       - conda
+      - dry-run-release
+      - nix
     steps:
       - uses: tibdex/github-app-token@v1
         id: generate_token
@@ -120,12 +181,6 @@ jobs:
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v2
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          fetch-depth: 0
-
-      - uses: actions/checkout@v2
-        if: ${{ github.event_name != 'pull_request' }}
         with:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
@@ -139,12 +194,7 @@ jobs:
           name: numbsql
           extraPullNames: nix-community,poetry2nix
 
-      - name: dry run semantic-release
-        if: ${{ github.event_name == 'pull_request' }}
-        run: ./ci/release/dry_run.sh
-
       - name: run semantic-release
-        if: ${{ github.event_name != 'pull_request' }}
         run: ./ci/release/run.sh
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}

--- a/flake.nix
+++ b/flake.nix
@@ -104,7 +104,7 @@
                   };
                 }
               ])
-            [ "37" "38" "39" ]
+            [ "37" "38" "39" "310" ]
         )))
       ];
     } // (
@@ -121,7 +121,8 @@
           packages.numbsql37 = pkgs.numbsql37;
           packages.numbsql38 = pkgs.numbsql38;
           packages.numbsql39 = pkgs.numbsql39;
-          packages.numbsql = pkgs.numbsql39;
+          packages.numbsql310 = pkgs.numbsql310;
+          packages.numbsql = pkgs.numbsql310;
 
           defaultPackage = packages.numbsql;
 
@@ -195,7 +196,7 @@
           devShell = pkgs.mkShell
             {
               nativeBuildInputs = with pkgs; [
-                numbsqlDevEnv39
+                numbsqlDevEnv310
                 poetry
                 prettierTOML
                 # useful for testing sqlite things with a sane CLI, i.e., with

--- a/poetry.lock
+++ b/poetry.lock
@@ -7,20 +7,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "argcomplete"
-version = "2.0.0"
-description = "Bash tab completion for argparse"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.23,<5", markers = "python_version == \"3.7\""}
-
-[package.extras]
-test = ["coverage", "flake8", "pexpect", "wheel"]
-
-[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -65,7 +51,10 @@ pathspec = ">=0.9.0,<1"
 platformdirs = ">=2"
 tomli = ">=0.2.6,<2.0.0"
 typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
-typing-extensions = ">=3.10.0.0"
+typing-extensions = [
+    {version = ">=3.10.0.0", markers = "python_version < \"3.10\""},
+    {version = "!=3.10.0.1", markers = "python_version >= \"3.10\""},
+]
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -195,7 +184,7 @@ python-versions = "*"
 
 [[package]]
 name = "ipykernel"
-version = "6.6.1"
+version = "6.7.0"
 description = "IPython Kernel for Jupyter"
 category = "dev"
 optional = false
@@ -203,9 +192,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 appnope = {version = "*", markers = "platform_system == \"Darwin\""}
-argcomplete = {version = ">=1.12.3", markers = "python_version < \"3.8.0\""}
 debugpy = ">=1.0.0,<2.0"
-importlib-metadata = {version = "<5", markers = "python_version < \"3.8.0\""}
 ipython = ">=7.23.1"
 jupyter-client = "<8.0"
 matplotlib-inline = ">=0.1.0,<0.2.0"
@@ -287,7 +274,7 @@ testing = ["Django (<3.1)", "colorama", "docopt", "pytest (<7.0.0)"]
 
 [[package]]
 name = "jsonschema"
-version = "4.3.3"
+version = "4.4.0"
 description = "An implementation of JSON Schema validation for Python"
 category = "dev"
 optional = false
@@ -392,11 +379,11 @@ python-versions = "*"
 
 [[package]]
 name = "nbclient"
-version = "0.5.9"
+version = "0.5.10"
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
 category = "dev"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.7.0"
 
 [package.dependencies]
 jupyter-client = ">=6.1.5"
@@ -405,9 +392,8 @@ nest-asyncio = "*"
 traitlets = ">=4.2"
 
 [package.extras]
-dev = ["codecov", "coverage", "ipython", "ipykernel", "ipywidgets", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "check-manifest", "flake8", "mypy", "tox", "xmltodict", "pip (>=18.1)", "wheel (>=0.31.0)", "setuptools (>=38.6.0)", "twine (>=1.11.0)", "black"]
 sphinx = ["Sphinx (>=1.7)", "sphinx-book-theme", "mock", "moto", "myst-parser"]
-test = ["codecov", "coverage", "ipython", "ipykernel", "ipywidgets", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "check-manifest", "flake8", "mypy", "tox", "xmltodict", "pip (>=18.1)", "wheel (>=0.31.0)", "setuptools (>=38.6.0)", "twine (>=1.11.0)", "black"]
+test = ["ipython", "ipykernel", "ipywidgets (<8.0.0)", "pytest (>=4.1)", "pytest-cov (>=2.6.1)", "check-manifest", "flake8", "mypy", "xmltodict", "black", "pip (>=18.1)", "wheel (>=0.31.0)", "setuptools (>=38.6.0)", "twine (>=1.11.0)"]
 
 [[package]]
 name = "nbformat"
@@ -685,11 +671,11 @@ pytest = ">=3.10"
 
 [[package]]
 name = "pytest-randomly"
-version = "3.10.3"
+version = "3.11.0"
 description = "Pytest plugin to randomly order tests and control random.seed."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
@@ -869,17 +855,13 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7.1,<3.10"
-content-hash = "70b69124f9756016334966b219e72249fe87b3f827883d30557bf0db0be2fd1a"
+python-versions = ">=3.7.1,<3.11"
+content-hash = "6df3ca3c78cc7e16e9a57d2888876468a8ca8c98e37f0c968b3eacb3f1d2a732"
 
 [metadata.files]
 appnope = [
     {file = "appnope-0.1.2-py2.py3-none-any.whl", hash = "sha256:93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442"},
     {file = "appnope-0.1.2.tar.gz", hash = "sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a"},
-]
-argcomplete = [
-    {file = "argcomplete-2.0.0-py2.py3-none-any.whl", hash = "sha256:cffa11ea77999bb0dd27bb25ff6dc142a6796142f68d45b1a26b11f58724561e"},
-    {file = "argcomplete-2.0.0.tar.gz", hash = "sha256:6372ad78c89d662035101418ae253668445b391755cfe94ea52f1b9d22425b20"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1009,8 +991,8 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 ipykernel = [
-    {file = "ipykernel-6.6.1-py3-none-any.whl", hash = "sha256:de99f6c1caa72578305cc96122ee3a19669e9c1958694a2b564ed1be28240ab9"},
-    {file = "ipykernel-6.6.1.tar.gz", hash = "sha256:91ff0058b45660aad4a68088041059c0d378cd53fc8aff60e5abc91bcc049353"},
+    {file = "ipykernel-6.7.0-py3-none-any.whl", hash = "sha256:6203ccd5510ff148e9433fd4a2707c5ce8d688f026427f46e13d7ebf9b3e9787"},
+    {file = "ipykernel-6.7.0.tar.gz", hash = "sha256:d82b904fdc2fd8c7b1fbe0fa481c68a11b4cd4c8ef07e6517da1f10cc3114d24"},
 ]
 ipython = [
     {file = "ipython-7.31.0-py3-none-any.whl", hash = "sha256:4c4234cdcc6b8f87c5b5c7af9899aa696ac5cfcf0e9f6d0688018bbee5c73bce"},
@@ -1029,8 +1011,8 @@ jedi = [
     {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.3.3-py3-none-any.whl", hash = "sha256:eb7a69801beb7325653aa8fd373abbf9ff8f85b536ab2812e5e8287b522fb6a2"},
-    {file = "jsonschema-4.3.3.tar.gz", hash = "sha256:f210d4ce095ed1e8af635d15c8ee79b586f656ab54399ba87b8ab87e5bff0ade"},
+    {file = "jsonschema-4.4.0-py3-none-any.whl", hash = "sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823"},
+    {file = "jsonschema-4.4.0.tar.gz", hash = "sha256:636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83"},
 ]
 jupyter-client = [
     {file = "jupyter_client-7.1.0-py3-none-any.whl", hash = "sha256:64d93752d8cbfba0c1030c3335c3f0d9797cd1efac012652a14aac1653db11a3"},
@@ -1102,8 +1084,8 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 nbclient = [
-    {file = "nbclient-0.5.9-py3-none-any.whl", hash = "sha256:8a307be4129cce5f70eb83a57c3edbe45656623c31de54e38bb6fdfbadc428b3"},
-    {file = "nbclient-0.5.9.tar.gz", hash = "sha256:99e46ddafacd0b861293bf246fed8540a184adfa3aa7d641f89031ec070701e0"},
+    {file = "nbclient-0.5.10-py3-none-any.whl", hash = "sha256:5b582e21c8b464e6676a9d60acc6871d7fbc3b080f74bef265a9f90411b31f6f"},
+    {file = "nbclient-0.5.10.tar.gz", hash = "sha256:b5fdea88d6fa52ca38de6c2361401cfe7aaa7cd24c74effc5e489cec04d79088"},
 ]
 nbformat = [
     {file = "nbformat-5.1.3-py3-none-any.whl", hash = "sha256:eb8447edd7127d043361bc17f2f5a807626bc8e878c7709a1c647abda28a9171"},
@@ -1274,8 +1256,8 @@ pytest-forked = [
     {file = "pytest_forked-1.4.0-py3-none-any.whl", hash = "sha256:bbbb6717efc886b9d64537b41fb1497cfaf3c9601276be8da2cccfea5a3c8ad8"},
 ]
 pytest-randomly = [
-    {file = "pytest-randomly-3.10.3.tar.gz", hash = "sha256:22154cdcff7ba44e0599596490e6b75278ca973a33812ea6a54bf14d0b042ef1"},
-    {file = "pytest_randomly-3.10.3-py3-none-any.whl", hash = "sha256:b05a7a45f54cae2b5095752c6a10cb559df84448421b0420ae492dd2fb1727ef"},
+    {file = "pytest-randomly-3.11.0.tar.gz", hash = "sha256:9f013b8c1923130f3d0a286fde56e1fc52cfb3547b8eedf2765c460cee979c7f"},
+    {file = "pytest_randomly-3.11.0-py3-none-any.whl", hash = "sha256:a3c680d2b8150cf766311a80a1f92da64c3dd819045cda834fbf1b0ac4891610"},
 ]
 pytest-xdist = [
     {file = "pytest-xdist-2.5.0.tar.gz", hash = "sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7.1,<3.10"
+python = ">=3.7.1,<3.11"
 llvmlite = ">=0.36,<0.39"
 numba = ">=0.53,<0.56"
 numpy = ">=1.21,<2"


### PR DESCRIPTION
- chore: default to python310 in flake.nix
- chore: allow python 3.10
- style: remove dash
- ci: run only on macos-latest
- style: add a bit of whitespace
- ci: give dry-run-release its own job
- ci: test python 3.10
- ci: sort the closure size output
- ci: try removing conda
- ci: rename conda step to poetry
