### PR TITLE
chore: clean up pyproject.toml and add back macos 3.10 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,6 @@ jobs:
           - os: macos-latest
             python-version: "37"
 
-            # 3.10 cannot be built with nixos-unstable-small as of 2022-01-14
-          - os: macos-latest
-            python-version: "310"
-
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,16 +51,6 @@ norecursedirs = ["site-packages", "dist-packages", ".direnv", "examples"]
 [tool.poetry2conda]
 name = "numbsql"
 
-[tool.semantic_release]
-version_toml = "pyproject.toml:tool.poetry.version"
-version_variable = "numbsql/__init__.py:__version__"
-branch = "main"
-upload_to_pypi = true
-upload_to_release = true
-build_command = "poetry build"
-commit_subject = "chore(release): {version}"
-commit_author = "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-
 [tool.isort]
 line_length = 88
 profile = "black"


### PR DESCRIPTION
- chore: remove unused pyproject.toml section
- ci: add macos python 3.10 back to CI
