### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -40,7 +40,7 @@ module.exports = {
       },
     ],
     [
-      "@google/semantic-release-replace-plugin",
+      "semantic-release-replace-plugin",
       {
         replacements: [
           {

--- a/ci/release/dry_run.sh
+++ b/ci/release/dry_run.sh
@@ -37,7 +37,7 @@ npx --yes \
   -p "@semantic-release/changelog" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "@google/semantic-release-replace-plugin" \
+  -p "semantic-release-replace-plugin" \
   -p "conventional-changelog-conventionalcommits" \
   semantic-release \
   --ci \

--- a/ci/release/run.sh
+++ b/ci/release/run.sh
@@ -12,6 +12,6 @@ npx --yes \
   -p "@semantic-release/github" \
   -p "@semantic-release/exec" \
   -p "@semantic-release/git" \
-  -p "@google/semantic-release-replace-plugin" \
+  -p "semantic-release-replace-plugin" \
   -p "conventional-changelog-conventionalcommits" \
   semantic-release --ci


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).